### PR TITLE
QU-2246: Add NGINX Basic Auth to Quine Enterprise Helm chart

### DIFF
--- a/charts/quine-enterprise/Chart.yaml
+++ b/charts/quine-enterprise/Chart.yaml
@@ -3,6 +3,6 @@ name: quine-enterprise
 description: A Helm chart for creating a thatDot Quine Enterprise cluster
 type: application
 
-version: 0.4.5
+version: 0.4.6
 
 appVersion: "1.8.1"

--- a/charts/quine-enterprise/Chart.yaml
+++ b/charts/quine-enterprise/Chart.yaml
@@ -5,4 +5,4 @@ type: application
 
 version: 0.4.6
 
-appVersion: "1.8.1"
+appVersion: "1.9.1"

--- a/charts/quine-enterprise/templates/_helpers.tpl
+++ b/charts/quine-enterprise/templates/_helpers.tpl
@@ -145,7 +145,7 @@ Basic Auth supporting volumes and volume mounts
 {{- if .Values.basicAuth.enabled }}
 - name: credentials-volume
   secret:
-    secretName: credentials
+    secretName: {{ include "quine-enterprise.fullname" . }}-credentials
 {{- end }}
 {{- end }}
 

--- a/charts/quine-enterprise/templates/_helpers.tpl
+++ b/charts/quine-enterprise/templates/_helpers.tpl
@@ -139,6 +139,25 @@ NGINX Basic Auth
 {{- end }}
 
 {{/*
+Basic Auth supporting volumes and volume mounts
+*/}}
+{{- define "quine-enterprise.basicAuthVolumes" }}
+{{- if .Values.basicAuth.enabled }}
+- name: credentials-volume
+  secret:
+    secretName: credentials
+{{- end }}
+{{- end }}
+
+{{- define "quine-enterprise.basicAuthVolumeMounts" }}
+{{- if .Values.basicAuth.enabled }}
+- name: credentials-volume
+  readOnly: true
+  mountPath: /credentials
+{{- end }}
+{{- end }}
+
+{{/*
 Liveness and Readiness Probes
 */}}
 {{- define "quine-enterprise.probes" -}}

--- a/charts/quine-enterprise/templates/_helpers.tpl
+++ b/charts/quine-enterprise/templates/_helpers.tpl
@@ -126,6 +126,17 @@ Cassandra Auth Environment
 {{- end }}
 {{- end }}
 
+{{/*
+NGINX Basic Auth
+*/}}
+{{- define "quine-enterprise.basicAuth" -}}
+{{- if .Values.basicAuth.enabled }}
+- name: USE_NGINX
+  value: "true"
+- name: USE_BASIC_AUTH
+  value: "true"
+{{- end}}
+{{- end}}
 
 {{/*
 Metrics Configuration Section

--- a/charts/quine-enterprise/templates/_helpers.tpl
+++ b/charts/quine-enterprise/templates/_helpers.tpl
@@ -135,8 +135,43 @@ NGINX Basic Auth
   value: "true"
 - name: USE_BASIC_AUTH
   value: "true"
-{{- end}}
-{{- end}}
+{{- end }}
+{{- end }}
+
+{{/*
+Liveness and Readiness Probes
+*/}}
+{{- define "quine-enterprise.probes" -}}
+{{- if not .Values.basicAuth.enabled }}
+livenessProbe:
+  httpGet:
+    path: /api/v1/admin/liveness
+    port: 8080
+  initialDelaySeconds: 5
+readinessProbe:
+  httpGet:
+    path: /api/v1/admin/liveness
+    port: 8080
+  initialDelaySeconds: 5
+{{- else }}
+livenessProbe:
+  exec:
+    command:
+    - curl
+    - '--silent'
+    - '--fail'
+    - http://localhost:8081/api/v1/admin/liveness
+  initialDelaySeconds: 5
+readinessProbe:
+  exec:
+    command:
+    - curl
+    - '--silent'
+    - '--fail'
+    - http://localhost:8081/api/v1/admin/liveness
+  initialDelaySeconds: 5
+{{- end }}
+{{- end }}
 
 {{/*
 Metrics Configuration Section

--- a/charts/quine-enterprise/templates/basic-auth-secret.yaml
+++ b/charts/quine-enterprise/templates/basic-auth-secret.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.basicAuth.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: credentials
+type: Opaque
+data:
+  htpasswd: {{ .Values.basicAuth.htpasswd | b64enc }}
+{{- end }}

--- a/charts/quine-enterprise/templates/basic-auth-secret.yaml
+++ b/charts/quine-enterprise/templates/basic-auth-secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: credentials
+  name: {{ include "quine-enterprise.fullname" . }}-credentials
 type: Opaque
 data:
   htpasswd: {{ .Values.basicAuth.htpasswd | b64enc }}

--- a/charts/quine-enterprise/templates/deployment.yaml
+++ b/charts/quine-enterprise/templates/deployment.yaml
@@ -59,16 +59,18 @@ spec:
           {{ include "quine-enterprise.probes" . | nindent 10 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- with .Values.volumeMounts }}
           volumeMounts:
+            {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- end }}
+            {{ include "quine-enterprise.basicAuthVolumeMounts" . | nindent 12 }}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
-      {{- with .Values.volumes }}
       volumes:
+        {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
+        {{ include "quine-enterprise.basicAuthVolumes" . | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/quine-enterprise/templates/deployment.yaml
+++ b/charts/quine-enterprise/templates/deployment.yaml
@@ -56,16 +56,7 @@ spec:
               {{ .Values.extraJdkArgs }}
           {{ include "quine-enterprise.cassandraAuthEnv" . | nindent 10 }}
           {{ include "quine-enterprise.basicAuth" . | nindent 10 }}
-          livenessProbe:
-            httpGet:
-              path: /api/v1/admin/liveness
-              port: 8080
-            initialDelaySeconds: 5
-          readinessProbe:
-            httpGet:
-              path: /api/v1/admin/liveness
-              port: 8080
-            initialDelaySeconds: 5
+          {{ include "quine-enterprise.probes" . | nindent 10 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- with .Values.volumeMounts }}

--- a/charts/quine-enterprise/templates/deployment.yaml
+++ b/charts/quine-enterprise/templates/deployment.yaml
@@ -55,6 +55,7 @@ spec:
               {{ include "quine-enterprise.trialConfiguration" . | nindent 14 }}
               {{ .Values.extraJdkArgs }}
           {{ include "quine-enterprise.cassandraAuthEnv" . | nindent 10 }}
+          {{ include "quine-enterprise.basicAuth" . | nindent 10 }}
           livenessProbe:
             httpGet:
               path: /api/v1/admin/liveness

--- a/charts/quine-enterprise/values.yaml
+++ b/charts/quine-enterprise/values.yaml
@@ -106,7 +106,19 @@ metrics:
     host: ""
     port: 8086
 
-# Enable Basic Authentication with NGINX
+# Enable HTTP Basic Authentication for the embedded NGINX reverse‑proxy.
+#
+# `htpasswd` must contain one or more lines in the exact format accepted by the
+# NGINX `auth_basic_user_file` directive:
+#   <username>:<hashed‑password>
+# See the official docs: https://nginx.org/en/docs/http/ngx_http_auth_basic_module.html#auth_basic_user_file
+#
+# Example on how to generate a hashed password:
+#   Creates a salt from 12 random bytes, encoded in base64.
+#   Uses that salt to generate a hashed password using the SHA256-crypt algorithm.
+#
+#   salt=$(openssl rand -base64 12)
+#   openssl passwd -5 -salt $salt
 basicAuth:
   enabled: false
   htpasswd: ""

--- a/charts/quine-enterprise/values.yaml
+++ b/charts/quine-enterprise/values.yaml
@@ -106,6 +106,10 @@ metrics:
     host: ""
     port: 8086
 
+# Enable Basic Authentication with NGINX
+basicAuth:
+  enabled: false
+  htpasswd: ""
 
 # Override image repository and tag to change the docker image used to run thatDot Quine Enterprise
 image:


### PR DESCRIPTION
This PR adds basic auth configuration for the Quine Enterprise Helm charts.

I've tested by using the following as my Helm `values.yaml`:

```yaml
hostCount: 1
trial:
  email: <EMAIL>
  apiKey: <API_KEY>
cassandra:
  enabled: false
basicAuth:
  enabled: true
  htpasswd: |
    admin:$5$43bYncTsEs/3DDiW$VZ51WLfPGoaGYgN4Ntl.kr/THksfFoEXQIaZNlBYYv.
```

Navigating to `localhost:8080` after port-forwarding the pod shows a request for basic auth. using `admin`/`admin` as the credentials successfully logs me in.

I create the hash using this script:

```bash
salt=$(openssl rand -base64 12)
openssl passwd -5 -salt $salt
```

Running the script results in a request for Password input. After entering a password (`admin` as above), a salted password is logged to stdout.