### PR TITLE
Add Novelty Metrics Reporters

### DIFF
--- a/charts/novelty/Chart.yaml
+++ b/charts/novelty/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: novelty
 description: thatDot Novelty Detector Helm Chart
 
-version: 0.4.2
-appVersion: 0.13.6
+version: 0.4.3
+appVersion: 0.14.0

--- a/charts/novelty/templates/_metrics.tpl
+++ b/charts/novelty/templates/_metrics.tpl
@@ -10,6 +10,14 @@ Prometheus Metrics Reporter Configuration
 -Dthatdot.novelty.metrics-reporters.0.period={{ .Values.metrics.csv.period }}
 -Dthatdot.novelty.metrics-reporters.0.log-directory={{ .Values.metrics.csv.logDirectory }}
 {{- end }}
+{{- if .Values.metrics.influx.enabled }}
+-Dthatdot.novelty.metrics-reporters.1.type=influxdb
+-Dthatdot.novelty.metrics-reporters.1.database={{ .Values.metrics.influx.database }}
+-Dthatdot.novelty.metrics-reporters.1.period={{ .Values.metrics.influx.period }}
+-Dthatdot.novelty.metrics-reporters.1.scheme={{ .Values.metrics.influx.scheme }}
+-Dthatdot.novelty.metrics-reporters.1.host={{ .Values.metrics.influx.host }}
+-Dthatdot.novelty.metrics-reporters.1.port={{ .Values.metrics.influx.port }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/novelty/templates/_metrics.tpl
+++ b/charts/novelty/templates/_metrics.tpl
@@ -1,7 +1,7 @@
 {{/*
 Prometheus Metrics Reporter Configuration
 */}}
-{{- define "novelty.prometheusJdkOptions" -}}
+{{- define "novelty.metricsJdkOptions" -}}
 {{- if .Values.metrics.prometheus.enabled }}
 -javaagent:jmx_prometheus_javaagent.jar={{ .Values.metrics.prometheus.port }}:/exporter.yaml
 {{- end }}

--- a/charts/novelty/templates/_metrics.tpl
+++ b/charts/novelty/templates/_metrics.tpl
@@ -18,6 +18,9 @@ Prometheus Metrics Reporter Configuration
 -Dthatdot.novelty.metrics-reporters.1.host={{ .Values.metrics.influx.host }}
 -Dthatdot.novelty.metrics-reporters.1.port={{ .Values.metrics.influx.port }}
 {{- end }}
+{{- if .Values.metrics.jmx.enabled }}
+-Dthatdot.novelty.metrics-reporters.2.type=jmx
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/novelty/templates/_metrics.tpl
+++ b/charts/novelty/templates/_metrics.tpl
@@ -2,9 +2,6 @@
 Prometheus Metrics Reporter Configuration
 */}}
 {{- define "novelty.metricsJdkOptions" -}}
-{{- if .Values.metrics.prometheus.enabled }}
--javaagent:jmx_prometheus_javaagent.jar={{ .Values.metrics.prometheus.port }}:/exporter.yaml
-{{- end }}
 {{- if .Values.metrics.csv.enabled }}
 -Dthatdot.novelty.metrics-reporters.0.type=csv
 -Dthatdot.novelty.metrics-reporters.0.period={{ .Values.metrics.csv.period }}
@@ -35,17 +32,5 @@ JMX Remote Settings
 -Dcom.sun.management.jmxremote.authenticate={{ .Values.jmxRemote.authenticate }}
 -Dcom.sun.management.jmxremote.ssl={{ .Values.jmxRemote.ssl }}
 -Djava.rmi.server.hostname={{ .Values.jmxRemote.rmiHostname }}
-{{- end }}
-{{- end }}
-
-{{/*
-Prometheus Annotations
-*/}}
-{{- define "novelty.prometheusAnnotations" -}}
-{{- if .Values.metrics.prometheus.enabled -}}
-annotations:
-  prometheus.io/scrape: "true"
-  prometheus.io/port: "{{ .Values.metrics.prometheus.port }}"
-  prometheus.io/path: "/metrics"
 {{- end }}
 {{- end }}

--- a/charts/novelty/templates/_metrics.tpl
+++ b/charts/novelty/templates/_metrics.tpl
@@ -24,6 +24,21 @@ Prometheus Metrics Reporter Configuration
 {{- end }}
 
 {{/*
+JMX Remote Settings
+*/}}
+{{- define "novelty.jmxJdkOptions" -}}
+{{- if .Values.jmxRemote.enabled }}
+-Dcom.sun.management.jmxremote
+-Dcom.sun.management.jmxremote.port={{ .Values.jmxRemote.port }}
+-Dcom.sun.management.jmxremote.rmi.port={{ .Values.jmxRemote.rmiPort }}
+-Dcom.sun.management.jmxremote.local.only={{ .Values.jmxRemote.localOnly }}
+-Dcom.sun.management.jmxremote.authenticate={{ .Values.jmxRemote.authenticate }}
+-Dcom.sun.management.jmxremote.ssl={{ .Values.jmxRemote.ssl }}
+-Djava.rmi.server.hostname={{ .Values.jmxRemote.rmiHostname }}
+{{- end }}
+{{- end }}
+
+{{/*
 Prometheus Annotations
 */}}
 {{- define "novelty.prometheusAnnotations" -}}

--- a/charts/novelty/templates/_prometheus.tpl
+++ b/charts/novelty/templates/_prometheus.tpl
@@ -8,7 +8,7 @@ Prometheus Metrics Reporter Configuration
 {{- if .Values.metrics.csv.enabled }}
 -Dthatdot.novelty.metrics-reporters.0.type=csv
 -Dthatdot.novelty.metrics-reporters.0.period={{ .Values.metrics.csv.period }}
--Dthatdot.novelty.metrics-reporters.0.log-directory={{ .Values.metrics.csv.log-directory }}
+-Dthatdot.novelty.metrics-reporters.0.log-directory={{ .Values.metrics.csv.logDirectory }}
 {{- end }}
 {{- end }}
 

--- a/charts/novelty/templates/_prometheus.tpl
+++ b/charts/novelty/templates/_prometheus.tpl
@@ -1,0 +1,20 @@
+{{/*
+Prometheus Metrics Reporter Configuration
+*/}}
+{{- define "novelty.prometheusJdkOptions" -}}
+{{- if .Values.metrics.prometheus.enabled }}
+-javaagent:jmx_prometheus_javaagent.jar={{ .Values.metrics.prometheus.port }}:/exporter.yaml
+{{- end }}
+{{- end }}
+
+{{/*
+Prometheus Annotations
+*/}}
+{{- define "novelty.prometheusAnnotations" -}}
+{{- if .Values.metrics.prometheus.enabled -}}
+annotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "{{ .Values.metrics.prometheus.port }}"
+  prometheus.io/path: "/metrics"
+{{- end }}
+{{- end }}

--- a/charts/novelty/templates/_prometheus.tpl
+++ b/charts/novelty/templates/_prometheus.tpl
@@ -5,6 +5,11 @@ Prometheus Metrics Reporter Configuration
 {{- if .Values.metrics.prometheus.enabled }}
 -javaagent:jmx_prometheus_javaagent.jar={{ .Values.metrics.prometheus.port }}:/exporter.yaml
 {{- end }}
+{{- if .Values.metrics.csv.enabled }}
+-Dthatdot.novelty.metrics-reporters.0.type=csv
+-Dthatdot.novelty.metrics-reporters.0.period={{ .Values.metrics.csv.period }}
+-Dthatdot.novelty.metrics-reporters.0.log-directory={{ .Values.metrics.csv.log-directory }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/novelty/templates/deployment.yaml
+++ b/charts/novelty/templates/deployment.yaml
@@ -11,7 +11,6 @@ spec:
       {{- include "novelty.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- include "novelty.prometheusAnnotations" . | nindent 6 }}
       labels:
         {{- include "novelty.labels" . | nindent 8 }}
     spec:

--- a/charts/novelty/templates/deployment.yaml
+++ b/charts/novelty/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           - name: JDK_JAVA_OPTIONS 
             value: |
               {{ include "novelty.trialConfiguration" . | nindent 14 }}
-              {{ include "novelty.prometheusJdkOptions" . | nindent 14 }}
+              {{ include "novelty.metricsJdkOptions" . | nindent 14 }}
               {{ .Values.extraJdkArgs }}
           ports:
           - containerPort: {{ .Values.service.internalPort }}

--- a/charts/novelty/templates/deployment.yaml
+++ b/charts/novelty/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
             value: |
               {{ include "novelty.trialConfiguration" . | nindent 14 }}
               {{ include "novelty.metricsJdkOptions" . | nindent 14 }}
+              {{ include "novelty.jmxJdkOptions" . | nindent 14 }}
               {{ .Values.extraJdkArgs }}
           ports:
           - containerPort: {{ .Values.service.internalPort }}

--- a/charts/novelty/templates/deployment.yaml
+++ b/charts/novelty/templates/deployment.yaml
@@ -11,6 +11,7 @@ spec:
       {{- include "novelty.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- include "novelty.prometheusAnnotations" . | nindent 6 }}
       labels:
         {{- include "novelty.labels" . | nindent 8 }}
     spec:
@@ -22,6 +23,7 @@ spec:
           - name: JDK_JAVA_OPTIONS 
             value: |
               {{ include "novelty.trialConfiguration" . | nindent 14 }}
+              {{ include "novelty.prometheusJdkOptions" . | nindent 14 }}
               {{ .Values.extraJdkArgs }}
           ports:
           - containerPort: {{ .Values.service.internalPort }}

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -14,6 +14,8 @@ trial:
 
 # Metrics Configuration: 
 metrics:
+  jmx:
+    enabled: false
   influx:
     enabled: false
     period: 30s

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -34,6 +34,15 @@ metrics:
     # Port opened up on Quine Enterprise pod, exposing Prometheus Java Agent metrics
     port: 9090
 
+jmxRemote:
+  enabled: false
+  port: 9010
+  rmiPort: 9010
+  localOnly: false
+  authenticate: false
+  ssl: false
+  rmiHostname: localhost
+
 image:
   repository: public.ecr.aws/thatdot/novelty-trial
   pullPolicy: IfNotPresent

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -29,6 +29,11 @@ metrics:
     period: 200ms
     logDirectory: /metrics
 
+# Java Management Extensions (JMX) and Remote Method Invocation (RMI) configuration
+#
+# These values configure JMX RMI. See the official docs in the following link
+# https://docs.oracle.com/javase/6/docs/technotes/guides/management/agent.html
+#
 jmxRemote:
   enabled: false
   port: 9010

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -17,7 +17,7 @@ metrics:
   csv:
     enabled: false
     period: 200ms
-    log-directory: /metrics
+    logDirectory: /metrics
   prometheus:
     # Set to true to expose JMX metrics over HTTP using the Prometheus JMX agent
     enabled: false

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -14,6 +14,10 @@ trial:
 
 # Metrics Configuration: 
 metrics:
+  csv:
+    enabled: false
+    period: 200ms
+    log-directory: /metrics
   prometheus:
     # Set to true to expose JMX metrics over HTTP using the Prometheus JMX agent
     enabled: false

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -28,11 +28,6 @@ metrics:
     enabled: false
     period: 200ms
     logDirectory: /metrics
-  prometheus:
-    # Set to true to expose JMX metrics over HTTP using the Prometheus JMX agent
-    enabled: false
-    # Port opened up on Quine Enterprise pod, exposing Prometheus Java Agent metrics
-    port: 9090
 
 jmxRemote:
   enabled: false

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -12,11 +12,19 @@ trial:
   email: ""
   apiKey: ""
 
+# Metrics Configuration: 
+metrics:
+  prometheus:
+    # Set to true to expose JMX metrics over HTTP using the Prometheus JMX agent
+    enabled: false
+    # Port opened up on Quine Enterprise pod, exposing Prometheus Java Agent metrics
+    port: 9090
+
 image:
   repository: public.ecr.aws/thatdot/novelty-trial
   pullPolicy: IfNotPresent
   tag: ""
-  
+
 service:
   name: novelty
   type: ClusterIP

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -14,6 +14,14 @@ trial:
 
 # Metrics Configuration: 
 metrics:
+  influx:
+    enabled: false
+    period: 30s
+    database: metrics
+    scheme: http
+    # Set "host" and "port" to the reachable address of the influx server
+    host: ""
+    port: 8086
   csv:
     enabled: false
     period: 200ms


### PR DESCRIPTION
This PR adds Helm values for the following Novelty metrics reports:

- JMX
- CSV
- InfluxDB

As a bonus, the PR also introduces `jmxRemote` options, allowing you to configure the internal JMX RMI server, allowing you to consume those metrics using VisualVM.

This was tested out with the following assets:

Novelty Values
```yaml
trial:
  email: <EMAIL>
  apiKey: <API_KEY>
metrics:
  jmx:
    enabled: true
  influx:
    enabled: true
    host: influx-influxdb
  csv:
    enabled: true
jmxRemote:
  enabled: true
```

Influx Values:
```yaml
initScripts:
  enabled: true
  scripts:
    metrics.sh: |
      #!/bin/bash
      influx --execute 'create database metrics'
image:
  repository: "influxdb"
  tag: "1.8"
setDefaultUser:
  enabled: true
  user:
    username: admin
    password: admin
```

Grafana Values:
```yaml
adminUser: admin
adminPassword: admin
datasources:
  datasources.yaml:
    apiVersion: 1
    datasources:
      - name: Novelty (InfluxDB)
        type: influxdb
        access: proxy
        orgId: 1
        url: http://influx-influxdb:8086
        database: metrics
        withCredentials: false
        isDefault: true
        jsonData:
          httpMode: POST
        version: 1
        editable: false
```

The script to run them all:
```bash
helm repo add grafana https://grafana.github.io/helm-charts
helm repo add influxdata https://helm.influxdata.com/
helm repo update

helm upgrade --install influx \
  influxdata/influxdb \
  -f influxdb-values.yaml

helm \
  upgrade --install grafana \
  grafana/grafana \
  -f grafana-values.yaml

helm \
  upgrade --install novelty \
  ../../helm-charts/charts/novelty \
  -f novelty-values.yaml
```