### PR TITLE
Add configuration for Novelty's Prometheus JMX Exporter

### DIFF
--- a/charts/novelty/Chart.yaml
+++ b/charts/novelty/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: novelty
 description: thatDot Novelty Detector Helm Chart
 
-version: 0.4.3
-appVersion: 0.14.0
+version: 0.4.4
+appVersion: 0.14.2

--- a/charts/novelty/templates/_metrics.tpl
+++ b/charts/novelty/templates/_metrics.tpl
@@ -15,7 +15,7 @@ Prometheus Metrics Reporter Configuration
 -Dthatdot.novelty.metrics-reporters.1.host={{ .Values.metrics.influx.host }}
 -Dthatdot.novelty.metrics-reporters.1.port={{ .Values.metrics.influx.port }}
 {{- end }}
-{{- if .Values.metrics.jmx.enabled }}
+{{- if or .Values.metrics.jmx.enabled .Values.metrics.prometheus.enabled }}
 -Dthatdot.novelty.metrics-reporters.2.type=jmx
 {{- end }}
 {{- end }}

--- a/charts/novelty/templates/_prometheus.tpl
+++ b/charts/novelty/templates/_prometheus.tpl
@@ -1,0 +1,19 @@
+{{/*
+Prometheus Metrics Reporter Configuration
+*/}}
+{{- define "novelty.prometheusJdkOptions" -}}
+{{- if .Values.metrics.prometheus.enabled }}
+-javaagent:jmx_prometheus_javaagent.jar={{ .Values.metrics.prometheus.port }}:/exporter.yaml
+{{- end }}
+{{- end }}
+
+{{/*
+Prometheus Annotations
+*/}}
+{{- define "novelty.prometheusAnnotations" -}}
+{{- if .Values.metrics.prometheus.enabled -}}
+prometheus.io/scrape: "true"
+prometheus.io/port: "{{ .Values.metrics.prometheus.port }}"
+prometheus.io/path: "/metrics"
+{{- end }}
+{{- end }}

--- a/charts/novelty/templates/deployment.yaml
+++ b/charts/novelty/templates/deployment.yaml
@@ -11,6 +11,11 @@ spec:
       {{- include "novelty.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- include "novelty.prometheusAnnotations" . | nindent 8 }}
       labels:
         {{- include "novelty.labels" . | nindent 8 }}
     spec:
@@ -24,6 +29,7 @@ spec:
               {{ include "novelty.trialConfiguration" . | nindent 14 }}
               {{ include "novelty.metricsJdkOptions" . | nindent 14 }}
               {{ include "novelty.jmxJdkOptions" . | nindent 14 }}
+              {{ include "novelty.prometheusJdkOptions" . | nindent 14 }}
               {{ .Values.extraJdkArgs }}
           ports:
           - containerPort: {{ .Values.service.internalPort }}

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -12,7 +12,7 @@ trial:
   email: ""
   apiKey: ""
 
-# Metrics Configuration: 
+# Metrics Configuration:
 metrics:
   jmx:
     enabled: false
@@ -28,6 +28,11 @@ metrics:
     enabled: false
     period: 200ms
     logDirectory: /metrics
+  prometheus:
+    # Set to true to expose JMX metrics over HTTP using the Prometheus JMX agent
+    enabled: false
+    # Port opened up on Quine Enterprise pod, exposing Prometheus Java Agent metrics
+    port: 9090
 
 # Java Management Extensions (JMX) and Remote Method Invocation (RMI) configuration
 #
@@ -61,6 +66,6 @@ resources:
   requests:
     cpu: 1024m
     memory: 2048Mi
-    
+
 # Whitespace-separated jdk arguments injected via JAVA_JDK_OPTIONS
 extraJdkArgs: ""


### PR DESCRIPTION
## Description

This PR adds prometheus configuration to the Novelty helm charts, enabling the Prometheus JMX Exporter in the Novelty image, along with adding Novelty pod annotations to enable easy integration with Prometheus Kubernetes service discovery.

## Helm Values

Run novelty with the following helm values to enable the Prometheus JMX exporter

`novelty-values.yaml`
```yaml
trial:
  email: <EMAIL>
  apiKey: <API_KEY>

metrics:
  prometheus:
    enabled: true
```

To assert Prometheus service discovery, run Prometheus with the following Helm values:

```yaml
server:
  global:
    scrape_interval: 15s
    scrape_timeout: 10s
configmapReload:
  prometheus:
    enabled: false
alertmanager:
  enabled: false
kube-state-metrics:
  enabled: false
prometheus-node-exporter:
  enabled: false
prometheus-pushgateway:
  enabled: false
```

Hook it all together with this script:

```bash
#!/bin/bash

helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
helm repo update

helm \
  upgrade --install \
  prometheus prometheus-community/prometheus \
  -f helm-values/prometheus-values.yaml

helm upgrade --install \
  novelty ./helm-charts/charts/novelty \ # This is the path to your local novelty helm chart
  -f helm-values/novelty-values.yaml
```

Running Prometheus shows the novelty pod due to the presence of annotations that enable service discovery