### PR TITLE
Set deployment strategy correctly for Quine charts

### DIFF
--- a/charts/quine-enterprise/Chart.yaml
+++ b/charts/quine-enterprise/Chart.yaml
@@ -3,6 +3,6 @@ name: quine-enterprise
 description: A Helm chart for creating a thatDot Quine Enterprise cluster
 type: application
 
-version: 0.4.7
+version: 0.4.8
 
 appVersion: "1.9.1"

--- a/charts/quine-enterprise/templates/_helpers.tpl
+++ b/charts/quine-enterprise/templates/_helpers.tpl
@@ -65,10 +65,22 @@ Create the name of the service account to use
 Cluster Join Type
 */}}
 {{- define "quine-enterprise.clusterJoinTypeConfiguration" -}}
-{{ if gt (int .Values.hostCount) 1 }}
+{{- if gt (int .Values.hostCount) 1 }}
 -Dquine.cluster.cluster-join.type=dns-entry 
 {{- end }}
 {{- end }}
+
+{{/* 
+Update Strategy
+NOTE: A cluster can use a rolling update, but two different single hosts should
+not share the persistor.
+*/}}
+{{- define "quine-enterprise.strategy" -}}
+{{ if gt (int .Values.hostCount) 1 }} RollingUpdate
+{{- else }} Recreate
+{{- end}}
+{{- end }}
+
 
 {{/*
 Persistence Config Section

--- a/charts/quine-enterprise/templates/deployment.yaml
+++ b/charts/quine-enterprise/templates/deployment.yaml
@@ -9,6 +9,8 @@ spec:
   selector:
     matchLabels:
       {{- include "quine-enterprise.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: {{- include "quine-enterprise.strategy" . }}
   template:
     metadata:
       annotations:

--- a/charts/quine/Chart.yaml
+++ b/charts/quine/Chart.yaml
@@ -3,6 +3,6 @@ name: quine
 description: A Helm chart for creating a thatDot Quine instance
 type: application
 
-version: 0.4.7
+version: 0.4.8
 
 appVersion: "1.9.1"

--- a/charts/quine/templates/deployment.yaml
+++ b/charts/quine/templates/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
     {{- include "quine.labels" . | nindent 4 }}
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "quine.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
Quine OSS and Quine Enterprise for a single host cluster should not share the same cassandra persistor keyspace. Therefore these helm charts should use the `Recreate` deployment strategy instead of the `RollingUpdate` strategy. This PR makes that change.