### PR TITLE
New Helm Chart Versions for Quine OSS and Enterprise

### DIFF
--- a/charts/quine-enterprise/Chart.yaml
+++ b/charts/quine-enterprise/Chart.yaml
@@ -3,6 +3,6 @@ name: quine-enterprise
 description: A Helm chart for creating a thatDot Quine Enterprise cluster
 type: application
 
-version: 0.4.8
+version: 0.4.9
 
-appVersion: "1.9.1"
+appVersion: "1.9.3"

--- a/charts/quine-enterprise/templates/_helpers.tpl
+++ b/charts/quine-enterprise/templates/_helpers.tpl
@@ -179,11 +179,13 @@ livenessProbe:
     path: /api/v1/admin/liveness
     port: 8080
   initialDelaySeconds: 5
+  timeoutSeconds: 10
 readinessProbe:
   httpGet:
     path: /api/v1/admin/liveness
     port: 8080
   initialDelaySeconds: 5
+  timeoutSeconds: 10
 {{- else }}
 livenessProbe:
   exec:

--- a/charts/quine/Chart.yaml
+++ b/charts/quine/Chart.yaml
@@ -3,6 +3,6 @@ name: quine
 description: A Helm chart for creating a thatDot Quine instance
 type: application
 
-version: 0.4.8
+version: 0.4.9
 
-appVersion: "1.9.1"
+appVersion: "1.9.3"

--- a/charts/quine/templates/_helpers.tpl
+++ b/charts/quine/templates/_helpers.tpl
@@ -126,11 +126,13 @@ livenessProbe:
     path: /api/v1/admin/liveness
     port: 8080
   initialDelaySeconds: 5
+  timeoutSeconds: 10
 readinessProbe:
   httpGet:
     path: /api/v1/admin/liveness
     port: 8080
   initialDelaySeconds: 5
+  timeoutSeconds: 10
 {{- end }}
 
 {{/*

--- a/charts/quine/templates/deployment.yaml
+++ b/charts/quine/templates/deployment.yaml
@@ -46,8 +46,6 @@ spec:
               -Dconfig.override_with_env_vars=true
               -Dthatdot.loglevel={{ .Values.thatdot.logLevel }} 
               -Dpekko.coordinated-shutdown.phases.before-cluster-shutdown.timeout="{{ sub .Values.memberTerminationGracePeriod 5 }} seconds"
-              -Dquine.id.type=uuid
-              -Dquine.id.partitioned=true
               {{ include "quine.persistenceConfiguration" . | nindent 14 }}
               {{ include "quine.storeConfiguration" . | nindent 14 }}
               {{ include "quine.metricsConfiguration" . | nindent 14 }}


### PR DESCRIPTION
Release new charts for Quine and Quine Enterprise version 1.9.3

- Updated liveness and readiness timeouts
- Update QuineId configuration for OSS chart.