### PR TITLE
replace trial helm values with enterprise/novelty license keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,8 @@ thatdot` to see the charts.
 
 The Quine Enterprise Helm chart can be used to deploy and manage a thatDot
 [Quine Enterprise](https://docs.thatdot.com/streaming-graph/index.html) cluster
-on Kubernetes.  This Helm chart works for both the trial version with a trial
-license and the full licensed version. Free trial licenses are available at
-[thatdot.com](https://www.thatdot.com/free-trial/).
+on Kubernetes. Quine Enterprise requires a valid license key provided by thatDot
+as part of an evaluation agreement or purchase order.
 
 ### Novelty
 
@@ -36,9 +35,8 @@ license and the full licensed version. Free trial licenses are available at
 
 The Novelty Helm chart can be used to deploy and manage thatDot
 [Novelty](https://docs.thatdot.com/novelty/getting-started/novelty-main-concepts.html)
-on Kubernetes.  This Helm chart works for both the trial version with a trial
-license and the full licensed version. Free trial licenses are available at
-[thatdot.com](https://www.thatdot.com/free-trial/).
+on Kubernetes. Novelty requires a valid license key provided by thatDot
+as part of an evaluation agreement or purchase order.
 
 ## Extras
 

--- a/charts/novelty/Chart.yaml
+++ b/charts/novelty/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: novelty
 description: thatDot Novelty Detector Helm Chart
 
-version: 0.4.4
-appVersion: 0.14.2
+version: 0.5.0
+appVersion: 1.0.0

--- a/charts/novelty/README.md
+++ b/charts/novelty/README.md
@@ -32,10 +32,16 @@ To uninstall the chart:
 helm delete my-novelty
 ```
 
-## Trial
+## License Key
 
-thatDot Novelty is priopriatary software. A free trial evaluation license is
-available from [thatdot.com](https://www.thatdot.com/free-trial/). When using
-this helm chart with a trial license, `Values.trial.enabled` must be set to
-true and the `Values.trial.email` and `Values.trial.apiKey` fields must be set.
-The API key will be sent via email after registering for a trial license.
+Novelty requires a valid license key to operate. The license key must be provided via the `licenseKey` configuration parameter.
+
+### Obtaining a License Key
+
+thatDot provides license keys as part of an evaluation agreement or purchase order. To schedule a demo or purchase a license, please:
+
+- Request a demo: [https://www.thatdot.com/request-a-demo/](https://www.thatdot.com/request-a-demo/)
+- Email sales: [sales@thatdot.com](mailto:sales@thatdot.com)
+- Contact thatDot: [https://www.thatdot.com/contact-us/](https://www.thatdot.com/contact-us/)
+
+When you receive your license key, thatDot will also provide the private Docker registry URL and credentials.

--- a/charts/novelty/templates/_helpers.tpl
+++ b/charts/novelty/templates/_helpers.tpl
@@ -98,3 +98,11 @@ OIDC Configuration Section
 {{- end }}
 {{- end }}
 
+{{/*
+Log Level Configuration Section
+*/}}
+{{- define "novelty.logLevelConfiguration" -}}
+{{- if .Values.thatdot.logLevel }}
+-Dthatdot.loglevel={{ .Values.thatdot.logLevel }}
+{{- end }}
+{{- end }}

--- a/charts/novelty/templates/_helpers.tpl
+++ b/charts/novelty/templates/_helpers.tpl
@@ -78,11 +78,11 @@ OIDC Configuration Section
 {{- if .Values.oidc.provider.loginPath }}
 -Dthatdot.novelty.auth.oidc.full.provider.login-path="{{ .Values.oidc.provider.loginPath }}"
 {{- end }}
-{{- if .Values.oidc.client.id }}
--Dthatdot.novelty.auth.oidc.full.client.id="{{ .Values.oidc.client.id }}"
-{{- end }}
-{{- if .Values.oidc.client.secret }}
--Dthatdot.novelty.auth.oidc.full.client.secret="{{ .Values.oidc.client.secret }}"
+{{- if .Values.oidc.client.existingSecret.name }}
+-Dthatdot.novelty.auth.oidc.full.client.id="${OIDC_CLIENT_ID}"
+-Dthatdot.novelty.auth.oidc.full.client.secret="${OIDC_CLIENT_SECRET}"
+{{- else }}
+{{- fail "oidc.client.existingSecret.name is required when oidc.enabled is true" }}
 {{- end }}
 {{- if .Values.oidc.session.autoGenerate }}
 -Dthatdot.novelty.auth.session.secret="{{ include "novelty.generateSessionSecret" . }}"

--- a/charts/novelty/templates/_helpers.tpl
+++ b/charts/novelty/templates/_helpers.tpl
@@ -51,13 +51,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-License Configuration Section
+License Key Secret Validation Section
 */}}
-{{- define "novelty.licenseConfiguration" -}}
-{{- if .Values.licenseKey }}
--Dthatdot.novelty.license-key={{ .Values.licenseKey }}
-{{- else }}
-{{- fail "licenseKey is required. Please provide a valid license key from thatDot." }}
+{{- define "novelty.licenseKeyValidation" -}}
+{{- if not .Values.licenseKeySecret.name }}
+{{- fail "licenseKeySecret.name is required. Please provide a valid license key secret from thatDot." }}
+{{- end }}
+{{- if not .Values.licenseKeySecret.key }}
+{{- fail "licenseKeySecret.key is required. Please specify the key containing the license key in the secret." }}
 {{- end }}
 {{- end }}
 

--- a/charts/novelty/templates/_helpers.tpl
+++ b/charts/novelty/templates/_helpers.tpl
@@ -51,11 +51,12 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Trial Configuration Section
+License Configuration Section
 */}}
-{{- define "novelty.trialConfiguration" -}}
-{{- if .Values.trial.enabled }}
--Dthatdot.novelty.trial.email={{ required "If trial version is enabled, Values.trial.email must be set" .Values.trial.email }}
--Dthatdot.novelty.trial.api-key={{ required "If trial version is enabled, Values.trial.apiKey must be set" .Values.trial.apiKey }}
+{{- define "novelty.licenseConfiguration" -}}
+{{- if .Values.licenseKey }}
+-Dthatdot.novelty.license-key={{ .Values.licenseKey }}
+{{- else }}
+{{- fail "licenseKey is required. Please provide a valid license key from thatDot." }}
 {{- end }}
 {{- end }}

--- a/charts/novelty/templates/_helpers.tpl
+++ b/charts/novelty/templates/_helpers.tpl
@@ -66,21 +66,33 @@ OIDC Configuration Section
 */}}
 {{- define "novelty.oidcConfiguration" -}}
 {{- if .Values.oidc.enabled }}
-{{- if .Values.oidc.provider.locationUrl }}
--Dthatdot.novelty.auth.oidc.full.provider.location-url="{{ .Values.oidc.provider.locationUrl }}"
+{{- if not .Values.oidc.provider.locationUrl }}
+{{- fail "oidc.provider.locationUrl is required when oidc.enabled is true" }}
 {{- end }}
-{{- if .Values.oidc.provider.authorizationUrl }}
--Dthatdot.novelty.auth.oidc.full.provider.authorization-url="{{ .Values.oidc.provider.authorizationUrl }}"
+{{- if not .Values.oidc.provider.authorizationUrl }}
+{{- fail "oidc.provider.authorizationUrl is required when oidc.enabled is true" }}
 {{- end }}
-{{- if .Values.oidc.provider.tokenUrl }}
--Dthatdot.novelty.auth.oidc.full.provider.token-url="{{ .Values.oidc.provider.tokenUrl }}"
+{{- if not .Values.oidc.provider.tokenUrl }}
+{{- fail "oidc.provider.tokenUrl is required when oidc.enabled is true" }}
 {{- end }}
-{{- if .Values.oidc.provider.loginPath }}
--Dthatdot.novelty.auth.oidc.full.provider.login-path="{{ .Values.oidc.provider.loginPath }}"
+{{- if not .Values.oidc.provider.loginPath }}
+{{- fail "oidc.provider.loginPath is required when oidc.enabled is true" }}
 {{- end }}
 {{- if not .Values.oidc.client.existingSecret.name }}
 {{- fail "oidc.client.existingSecret.name is required when oidc.enabled is true" }}
 {{- end }}
+{{- if not .Values.oidc.session.autoGenerate }}
+{{- if not .Values.oidc.session.existingSecret.name }}
+{{- fail "oidc.session.existingSecret.name is required when oidc.enabled is true and autoGenerate is false" }}
+{{- end }}
+{{- if not .Values.oidc.session.existingSecret.key }}
+{{- fail "oidc.session.existingSecret.key is required when oidc.enabled is true and autoGenerate is false" }}
+{{- end }}
+{{- end }}
+-Dthatdot.novelty.auth.oidc.full.provider.location-url="{{ .Values.oidc.provider.locationUrl }}"
+-Dthatdot.novelty.auth.oidc.full.provider.authorization-url="{{ .Values.oidc.provider.authorizationUrl }}"
+-Dthatdot.novelty.auth.oidc.full.provider.token-url="{{ .Values.oidc.provider.tokenUrl }}"
+-Dthatdot.novelty.auth.oidc.full.provider.login-path="{{ .Values.oidc.provider.loginPath }}"
 -Dthatdot.novelty.auth.session.expiration-seconds={{ .Values.oidc.session.expirationSeconds }}
 -Dthatdot.novelty.auth.session.secure-cookies={{ .Values.oidc.session.secureCookies }}
 {{- end }}

--- a/charts/novelty/templates/_helpers.tpl
+++ b/charts/novelty/templates/_helpers.tpl
@@ -84,10 +84,23 @@ OIDC Configuration Section
 {{- if .Values.oidc.client.secret }}
 -Dthatdot.novelty.auth.oidc.full.client.secret="{{ .Values.oidc.client.secret }}"
 {{- end }}
-{{- if .Values.oidc.session.secret }}
+{{- if .Values.oidc.session.autoGenerate }}
+-Dthatdot.novelty.auth.session.secret="{{ include "novelty.generateSessionSecret" . }}"
+{{- else if .Values.oidc.session.existingSecret.name }}
+-Dthatdot.novelty.auth.session.secret="${OIDC_SESSION_SECRET}"
+{{- else if .Values.oidc.session.secret }}
 -Dthatdot.novelty.auth.session.secret="{{ .Values.oidc.session.secret }}"
 {{- end }}
 -Dthatdot.novelty.auth.session.expiration-seconds={{ .Values.oidc.session.expirationSeconds }}
 -Dthatdot.novelty.auth.session.secure-cookies={{ .Values.oidc.session.secureCookies }}
 {{- end }}
+{{- end }}
+
+{{/*
+Generate a random alphanumeric session secret (32 characters)
+This uses Helm's built-in randAlphaNum function to create a deterministic
+random string that will remain constant for the lifetime of the release.
+*/}}
+{{- define "novelty.generateSessionSecret" -}}
+{{- randAlphaNum 32 }}
 {{- end }}

--- a/charts/novelty/templates/_helpers.tpl
+++ b/charts/novelty/templates/_helpers.tpl
@@ -78,29 +78,11 @@ OIDC Configuration Section
 {{- if .Values.oidc.provider.loginPath }}
 -Dthatdot.novelty.auth.oidc.full.provider.login-path="{{ .Values.oidc.provider.loginPath }}"
 {{- end }}
-{{- if .Values.oidc.client.existingSecret.name }}
--Dthatdot.novelty.auth.oidc.full.client.id="${OIDC_CLIENT_ID}"
--Dthatdot.novelty.auth.oidc.full.client.secret="${OIDC_CLIENT_SECRET}"
-{{- else }}
+{{- if not .Values.oidc.client.existingSecret.name }}
 {{- fail "oidc.client.existingSecret.name is required when oidc.enabled is true" }}
-{{- end }}
-{{- if .Values.oidc.session.autoGenerate }}
--Dthatdot.novelty.auth.session.secret="{{ include "novelty.generateSessionSecret" . }}"
-{{- else if .Values.oidc.session.existingSecret.name }}
--Dthatdot.novelty.auth.session.secret="${OIDC_SESSION_SECRET}"
-{{- else if .Values.oidc.session.secret }}
--Dthatdot.novelty.auth.session.secret="{{ .Values.oidc.session.secret }}"
 {{- end }}
 -Dthatdot.novelty.auth.session.expiration-seconds={{ .Values.oidc.session.expirationSeconds }}
 -Dthatdot.novelty.auth.session.secure-cookies={{ .Values.oidc.session.secureCookies }}
 {{- end }}
 {{- end }}
 
-{{/*
-Generate a random alphanumeric session secret (32 characters)
-This uses Helm's built-in randAlphaNum function to create a deterministic
-random string that will remain constant for the lifetime of the release.
-*/}}
-{{- define "novelty.generateSessionSecret" -}}
-{{- randAlphaNum 32 }}
-{{- end }}

--- a/charts/novelty/templates/_helpers.tpl
+++ b/charts/novelty/templates/_helpers.tpl
@@ -60,3 +60,34 @@ License Configuration Section
 {{- fail "licenseKey is required. Please provide a valid license key from thatDot." }}
 {{- end }}
 {{- end }}
+
+{{/*
+OIDC Configuration Section
+*/}}
+{{- define "novelty.oidcConfiguration" -}}
+{{- if .Values.oidc.enabled }}
+{{- if .Values.oidc.provider.locationUrl }}
+-Dthatdot.novelty.auth.oidc.full.provider.location-url="{{ .Values.oidc.provider.locationUrl }}"
+{{- end }}
+{{- if .Values.oidc.provider.authorizationUrl }}
+-Dthatdot.novelty.auth.oidc.full.provider.authorization-url="{{ .Values.oidc.provider.authorizationUrl }}"
+{{- end }}
+{{- if .Values.oidc.provider.tokenUrl }}
+-Dthatdot.novelty.auth.oidc.full.provider.token-url="{{ .Values.oidc.provider.tokenUrl }}"
+{{- end }}
+{{- if .Values.oidc.provider.loginPath }}
+-Dthatdot.novelty.auth.oidc.full.provider.login-path="{{ .Values.oidc.provider.loginPath }}"
+{{- end }}
+{{- if .Values.oidc.client.id }}
+-Dthatdot.novelty.auth.oidc.full.client.id="{{ .Values.oidc.client.id }}"
+{{- end }}
+{{- if .Values.oidc.client.secret }}
+-Dthatdot.novelty.auth.oidc.full.client.secret="{{ .Values.oidc.client.secret }}"
+{{- end }}
+{{- if .Values.oidc.session.secret }}
+-Dthatdot.novelty.auth.session.secret="{{ .Values.oidc.session.secret }}"
+{{- end }}
+-Dthatdot.novelty.auth.session.expiration-seconds={{ .Values.oidc.session.expirationSeconds }}
+-Dthatdot.novelty.auth.session.secure-cookies={{ .Values.oidc.session.secureCookies }}
+{{- end }}
+{{- end }}

--- a/charts/novelty/templates/deployment.yaml
+++ b/charts/novelty/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
           - name: JDK_JAVA_OPTIONS
             value: |
               {{ include "novelty.licenseConfiguration" . | nindent 14 }}
+              {{ include "novelty.oidcConfiguration" . | nindent 14 }}
               {{ include "novelty.metricsJdkOptions" . | nindent 14 }}
               {{ include "novelty.jmxJdkOptions" . | nindent 14 }}
               {{ include "novelty.prometheusJdkOptions" . | nindent 14 }}

--- a/charts/novelty/templates/deployment.yaml
+++ b/charts/novelty/templates/deployment.yaml
@@ -39,6 +39,18 @@ spec:
                 name: {{ .Values.oidc.session.existingSecret.name }}
                 key: {{ .Values.oidc.session.existingSecret.key }}
           {{- end }}
+          {{- if and .Values.oidc.enabled .Values.oidc.client.existingSecret.name }}
+          - name: OIDC_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.oidc.client.existingSecret.name }}
+                key: {{ .Values.oidc.client.existingSecret.secretKeys.clientIdKey }}
+          - name: OIDC_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.oidc.client.existingSecret.name }}
+                key: {{ .Values.oidc.client.existingSecret.secretKeys.clientSecretKey }}
+          {{- end }}
           ports:
           - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/novelty/templates/deployment.yaml
+++ b/charts/novelty/templates/deployment.yaml
@@ -26,30 +26,34 @@ spec:
           env:
           - name: JDK_JAVA_OPTIONS
             value: |
+              -Dconfig.override_with_env_vars=true
               {{ include "novelty.licenseConfiguration" . | nindent 14 }}
               {{ include "novelty.oidcConfiguration" . | nindent 14 }}
               {{ include "novelty.metricsJdkOptions" . | nindent 14 }}
               {{ include "novelty.jmxJdkOptions" . | nindent 14 }}
               {{ include "novelty.prometheusJdkOptions" . | nindent 14 }}
               {{ .Values.extraJdkArgs }}
-          {{- if and (not .Values.oidc.session.autoGenerate) .Values.oidc.session.existingSecret.name }}
-          - name: OIDC_SESSION_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.oidc.session.existingSecret.name }}
-                key: {{ .Values.oidc.session.existingSecret.key }}
-          {{- end }}
           {{- if and .Values.oidc.enabled .Values.oidc.client.existingSecret.name }}
-          - name: OIDC_CLIENT_ID
+          - name: CONFIG_FORCE_thatdot_novelty_auth_oidc_full_client_id
             valueFrom:
               secretKeyRef:
                 name: {{ .Values.oidc.client.existingSecret.name }}
                 key: {{ .Values.oidc.client.existingSecret.secretKeys.clientIdKey }}
-          - name: OIDC_CLIENT_SECRET
+          - name: CONFIG_FORCE_thatdot_novelty_auth_oidc_full_client_secret
             valueFrom:
               secretKeyRef:
                 name: {{ .Values.oidc.client.existingSecret.name }}
                 key: {{ .Values.oidc.client.existingSecret.secretKeys.clientSecretKey }}
+          {{- end }}
+          {{- if .Values.oidc.session.autoGenerate }}
+          - name: CONFIG_FORCE_thatdot_novelty_auth_session_secret
+            value: "{{ randAlphaNum 32 }}"
+          {{- else if .Values.oidc.session.existingSecret.name }}
+          - name: CONFIG_FORCE_thatdot_novelty_auth_session_secret
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.oidc.session.existingSecret.name }}
+                key: {{ .Values.oidc.session.existingSecret.key }}
           {{- end }}
           ports:
           - containerPort: {{ .Values.service.internalPort }}

--- a/charts/novelty/templates/deployment.yaml
+++ b/charts/novelty/templates/deployment.yaml
@@ -45,6 +45,7 @@ spec:
                 name: {{ .Values.oidc.client.existingSecret.name }}
                 key: {{ .Values.oidc.client.existingSecret.secretKeys.clientSecretKey }}
           {{- end }}
+          {{- if .Values.oidc.enabled }}
           {{- if .Values.oidc.session.autoGenerate }}
           - name: CONFIG_FORCE_thatdot_novelty_auth_session_secret
             value: "{{ randAlphaNum 32 }}"
@@ -54,6 +55,7 @@ spec:
               secretKeyRef:
                 name: {{ .Values.oidc.session.existingSecret.name }}
                 key: {{ .Values.oidc.session.existingSecret.key }}
+          {{- end }}
           {{- end }}
           ports:
           - containerPort: {{ .Values.service.internalPort }}

--- a/charts/novelty/templates/deployment.yaml
+++ b/charts/novelty/templates/deployment.yaml
@@ -32,6 +32,13 @@ spec:
               {{ include "novelty.jmxJdkOptions" . | nindent 14 }}
               {{ include "novelty.prometheusJdkOptions" . | nindent 14 }}
               {{ .Values.extraJdkArgs }}
+          {{- if and (not .Values.oidc.session.autoGenerate) .Values.oidc.session.existingSecret.name }}
+          - name: OIDC_SESSION_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.oidc.session.existingSecret.name }}
+                key: {{ .Values.oidc.session.existingSecret.key }}
+          {{- end }}
           ports:
           - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/novelty/templates/deployment.yaml
+++ b/charts/novelty/templates/deployment.yaml
@@ -59,12 +59,12 @@ spec:
           - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:
             httpGet:
-              path: /api/v1/admin/liveness
+              path: /api/v2/admin/liveness
               port: 8080
             initialDelaySeconds: 5
           readinessProbe:
             httpGet:
-              path: /api/v1/admin/liveness
+              path: /api/v2/admin/liveness
               port: 8080
             initialDelaySeconds: 5
           resources:

--- a/charts/novelty/templates/deployment.yaml
+++ b/charts/novelty/templates/deployment.yaml
@@ -28,7 +28,6 @@ spec:
             value: |
               -Dconfig.override_with_env_vars=true
               {{ include "novelty.logLevelConfiguration" . | nindent 14 }}
-              {{ include "novelty.licenseConfiguration" . | nindent 14 }}
               {{ include "novelty.oidcConfiguration" . | nindent 14 }}
               {{ include "novelty.metricsJdkOptions" . | nindent 14 }}
               {{ include "novelty.jmxJdkOptions" . | nindent 14 }}
@@ -61,6 +60,12 @@ spec:
                 key: {{ .Values.oidc.session.existingSecret.key }}
           {{- end }}
           {{- end }}
+          {{ include "novelty.licenseKeyValidation" . }}
+          - name: CONFIG_FORCE_thatdot_novelty_license__key
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.licenseKeySecret.name }}
+                key: {{ .Values.licenseKeySecret.key }}
           ports:
           - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/novelty/templates/deployment.yaml
+++ b/charts/novelty/templates/deployment.yaml
@@ -24,9 +24,9 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-          - name: JDK_JAVA_OPTIONS 
+          - name: JDK_JAVA_OPTIONS
             value: |
-              {{ include "novelty.trialConfiguration" . | nindent 14 }}
+              {{ include "novelty.licenseConfiguration" . | nindent 14 }}
               {{ include "novelty.metricsJdkOptions" . | nindent 14 }}
               {{ include "novelty.jmxJdkOptions" . | nindent 14 }}
               {{ include "novelty.prometheusJdkOptions" . | nindent 14 }}

--- a/charts/novelty/templates/deployment.yaml
+++ b/charts/novelty/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
           - name: JDK_JAVA_OPTIONS
             value: |
               -Dconfig.override_with_env_vars=true
+              {{ include "novelty.logLevelConfiguration" . | nindent 14 }}
               {{ include "novelty.licenseConfiguration" . | nindent 14 }}
               {{ include "novelty.oidcConfiguration" . | nindent 14 }}
               {{ include "novelty.metricsJdkOptions" . | nindent 14 }}

--- a/charts/novelty/templates/deployment.yaml
+++ b/charts/novelty/templates/deployment.yaml
@@ -48,7 +48,10 @@ spec:
           {{- if .Values.oidc.enabled }}
           {{- if .Values.oidc.session.autoGenerate }}
           - name: CONFIG_FORCE_thatdot_novelty_auth_session_secret
-            value: "{{ randAlphaNum 45 }}"
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "novelty.fullname" . }}-session-secret
+                key: secret
           {{- else if .Values.oidc.session.existingSecret.name }}
           - name: CONFIG_FORCE_thatdot_novelty_auth_session_secret
             valueFrom:

--- a/charts/novelty/templates/deployment.yaml
+++ b/charts/novelty/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
           {{- if .Values.oidc.enabled }}
           {{- if .Values.oidc.session.autoGenerate }}
           - name: CONFIG_FORCE_thatdot_novelty_auth_session_secret
-            value: "{{ randAlphaNum 32 }}"
+            value: "{{ randAlphaNum 45 }}"
           {{- else if .Values.oidc.session.existingSecret.name }}
           - name: CONFIG_FORCE_thatdot_novelty_auth_session_secret
             valueFrom:

--- a/charts/novelty/templates/session-secret.yaml
+++ b/charts/novelty/templates/session-secret.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.oidc.enabled .Values.oidc.session.autoGenerate }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "novelty.fullname" . }}-session-secret
+  labels:
+    {{- include "novelty.labels" . | nindent 4 }}
+type: Opaque
+data:
+  secret: {{ randAlphaNum 45 | b64enc | quote }}
+{{- end }}

--- a/charts/novelty/templates/session-secret.yaml
+++ b/charts/novelty/templates/session-secret.yaml
@@ -1,11 +1,17 @@
 {{- if and .Values.oidc.enabled .Values.oidc.session.autoGenerate }}
+{{- $secretName := printf "%s-session-secret" (include "novelty.fullname" .) }}
+{{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace $secretName) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "novelty.fullname" . }}-session-secret
+  name: {{ $secretName }}
   labels:
     {{- include "novelty.labels" . | nindent 4 }}
 type: Opaque
 data:
+  {{- if .Release.IsInstall }}
   secret: {{ randAlphaNum 45 | b64enc | quote }}
+  {{- else }}
+  secret: {{ index $existingSecret.data "secret" }}
+  {{- end }}
 {{- end }}

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -7,10 +7,8 @@ fullnameOverride: ""
 
 replicaCount: 1
 
-trial:
-  enabled: true
-  email: ""
-  apiKey: ""
+# License key required for Novelty
+licenseKey: ""
 
 # Metrics Configuration:
 metrics:
@@ -48,10 +46,14 @@ jmxRemote:
   ssl: false
   rmiHostname: localhost
 
+# The registry URL and credentials are provided by thatDot with your license key
 image:
-  repository: public.ecr.aws/thatdot/novelty-trial
+  repository: ""
   pullPolicy: IfNotPresent
   tag: ""
+
+# Registry credentials provided by thatDot
+imagePullSecrets: []
 
 service:
   name: novelty

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -76,7 +76,7 @@ oidc:
     locationUrl: ""
     authorizationUrl: ""
     tokenUrl: ""
-    loginPath: "auth"
+    loginPath: ""
   client:
     existingSecret:
       name: "novelty-oidc-credentials"

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 # License key secret required for Novelty
 licenseKeySecret:
   name: ""
-  key: ""
+  key: "license-key"
 
 # Metrics Configuration:
 metrics:

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -78,8 +78,11 @@ oidc:
     tokenUrl: ""
     loginPath: "auth"
   client:
-    id: ""
-    secret: ""
+    existingSecret:
+      name: ""
+      secretKeys:
+        clientIdKey: "client-id"
+        clientSecretKey: "client-secret"
   session:
     autoGenerate: true
     existingSecret:

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -91,5 +91,10 @@ oidc:
     expirationSeconds: 3600
     secureCookies: true
 
+# Logging Configuration
+thatdot:
+  # Cluster-wide log level (ERROR, WARN, INFO, DEBUG)
+  logLevel: WARN
+
 # Whitespace-separated jdk arguments injected via JAVA_JDK_OPTIONS
 extraJdkArgs: ""

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -88,7 +88,6 @@ oidc:
     existingSecret:
       name: ""
       key: ""
-    secret: ""
     expirationSeconds: 3600
     secureCookies: true
 

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -7,8 +7,10 @@ fullnameOverride: ""
 
 replicaCount: 1
 
-# License key required for Novelty
-licenseKey: ""
+# License key secret required for Novelty
+licenseKeySecret:
+  name: ""
+  key: ""
 
 # Metrics Configuration:
 metrics:

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -79,7 +79,7 @@ oidc:
     loginPath: "auth"
   client:
     existingSecret:
-      name: ""
+      name: "novelty-oidc-credentials"
       secretKeys:
         clientIdKey: "client-id"
         clientSecretKey: "client-secret"

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -90,7 +90,7 @@ oidc:
       key: ""
     secret: ""
     expirationSeconds: 3600
-    secureCookies: false
+    secureCookies: true
 
 # Whitespace-separated jdk arguments injected via JAVA_JDK_OPTIONS
 extraJdkArgs: ""

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -69,5 +69,21 @@ resources:
     cpu: 1024m
     memory: 2048Mi
 
+# OIDC Configuration for OpenID Connect authentication
+oidc:
+  enabled: false
+  provider:
+    locationUrl: ""
+    authorizationUrl: ""
+    tokenUrl: ""
+    loginPath: "auth"
+  client:
+    id: ""
+    secret: ""
+  session:
+    secret: ""
+    expirationSeconds: 3600
+    secureCookies: false
+
 # Whitespace-separated jdk arguments injected via JAVA_JDK_OPTIONS
 extraJdkArgs: ""

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -79,7 +79,7 @@ oidc:
     loginPath: ""
   client:
     existingSecret:
-      name: "novelty-oidc-credentials"
+      name: ""
       secretKeys:
         clientIdKey: "client-id"
         clientSecretKey: "client-secret"

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -73,24 +73,37 @@ resources:
 
 # OIDC Configuration for OpenID Connect authentication
 oidc:
+  # Enable OpenID Connect authentication
   enabled: false
   provider:
+    # OIDC provider base URL
     locationUrl: ""
+    # OAuth2 authorization endpoint for login requests
     authorizationUrl: ""
+    # OAuth2 token endpoint for exchanging auth codes
     tokenUrl: ""
+    # OIDC provider's login endpoint path (appended to locationUrl for user redirect)
     loginPath: ""
   client:
     existingSecret:
+      # Kubernetes secret containing OIDC client credentials
       name: ""
       secretKeys:
+        # Secret key name containing the OIDC client ID
         clientIdKey: "client-id"
+        # Secret key name containing the OIDC client secret
         clientSecretKey: "client-secret"
   session:
+    # Auto-generate session encryption key if no existing secret provided
     autoGenerate: true
     existingSecret:
+      # Kubernetes secret containing session encryption key (if not auto-generating)
       name: ""
+      # Secret key name containing the session encryption key
       key: ""
+    # Session timeout
     expirationSeconds: 3600
+    # Use HTTPS-only secure cookies for session handling
     secureCookies: true
 
 # Logging Configuration

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -81,6 +81,10 @@ oidc:
     id: ""
     secret: ""
   session:
+    autoGenerate: true
+    existingSecret:
+      name: ""
+      key: ""
     secret: ""
     expirationSeconds: 3600
     secureCookies: false

--- a/charts/quine-enterprise/Chart.yaml
+++ b/charts/quine-enterprise/Chart.yaml
@@ -3,6 +3,6 @@ name: quine-enterprise
 description: A Helm chart for creating a thatDot Quine Enterprise cluster
 type: application
 
-version: 0.4.9
+version: 0.5.0
 
-appVersion: "1.9.3"
+appVersion: "2.0.0"

--- a/charts/quine-enterprise/README.md
+++ b/charts/quine-enterprise/README.md
@@ -51,10 +51,16 @@ To uninstall the chart:
 helm delete my-quine-enterprise
 ```
 
-## Trial
+## License Key
 
-Quine Enterprise is proprietary software. A free trial evaluation license is
-available from [thatdot.com](https://www.thatdot.com/free-trial/). When using
-this helm chart with a trial license, `Values.trial.enabled` must be set to
-true and the `Values.trial.email` and `Values.trial.apiKey` fields must be set.
-The API key will be sent via email after registering for a trial license.
+Quine Enterprise requires a valid license key to operate. The license key must be provided via the `licenseKey` configuration parameter.
+
+### Obtaining a License Key
+
+thatDot provides license keys as part of an evaluation agreement or purchase order. To schedule a demo or purchase a license, please:
+
+- Request a demo: [https://www.thatdot.com/request-a-demo/](https://www.thatdot.com/request-a-demo/)
+- Email sales: [sales@thatdot.com](mailto:sales@thatdot.com)
+- Contact thatDot: [https://www.thatdot.com/contact-us/](https://www.thatdot.com/contact-us/)
+
+When you receive your license key, thatDot will also provide the private Docker registry URL and credentials.

--- a/charts/quine-enterprise/templates/_helpers.tpl
+++ b/charts/quine-enterprise/templates/_helpers.tpl
@@ -230,3 +230,34 @@ License Configuration Section
 {{- fail "licenseKey is required. Please provide a valid license key from thatDot." }}
 {{- end }}
 {{- end }}
+
+{{/*
+OIDC Configuration Section
+*/}}
+{{- define "quine-enterprise.oidcConfiguration" -}}
+{{- if .Values.oidc.enabled }}
+{{- if .Values.oidc.provider.locationUrl }}
+-Dquine.auth.oidc.full.provider.location-url="{{ .Values.oidc.provider.locationUrl }}"
+{{- end }}
+{{- if .Values.oidc.provider.authorizationUrl }}
+-Dquine.auth.oidc.full.provider.authorization-url="{{ .Values.oidc.provider.authorizationUrl }}"
+{{- end }}
+{{- if .Values.oidc.provider.tokenUrl }}
+-Dquine.auth.oidc.full.provider.token-url="{{ .Values.oidc.provider.tokenUrl }}"
+{{- end }}
+{{- if .Values.oidc.provider.loginPath }}
+-Dquine.auth.oidc.full.provider.login-path="{{ .Values.oidc.provider.loginPath }}"
+{{- end }}
+{{- if .Values.oidc.client.id }}
+-Dquine.auth.oidc.full.client.id="{{ .Values.oidc.client.id }}"
+{{- end }}
+{{- if .Values.oidc.client.secret }}
+-Dquine.auth.oidc.full.client.secret="{{ .Values.oidc.client.secret }}"
+{{- end }}
+{{- if .Values.oidc.session.secret }}
+-Dquine.auth.session.secret="{{ .Values.oidc.session.secret }}"
+{{- end }}
+-Dquine.auth.session.expiration-seconds={{ .Values.oidc.session.expirationSeconds }}
+-Dquine.auth.session.secure-cookies={{ .Values.oidc.session.secureCookies }}
+{{- end }}
+{{- end }}

--- a/charts/quine-enterprise/templates/_helpers.tpl
+++ b/charts/quine-enterprise/templates/_helpers.tpl
@@ -186,21 +186,33 @@ OIDC Configuration Section
 */}}
 {{- define "quine-enterprise.oidcConfiguration" -}}
 {{- if .Values.oidc.enabled }}
-{{- if .Values.oidc.provider.locationUrl }}
--Dquine.auth.oidc.full.provider.location-url="{{ .Values.oidc.provider.locationUrl }}"
+{{- if not .Values.oidc.provider.locationUrl }}
+{{- fail "oidc.provider.locationUrl is required when oidc.enabled is true" }}
 {{- end }}
-{{- if .Values.oidc.provider.authorizationUrl }}
--Dquine.auth.oidc.full.provider.authorization-url="{{ .Values.oidc.provider.authorizationUrl }}"
+{{- if not .Values.oidc.provider.authorizationUrl }}
+{{- fail "oidc.provider.authorizationUrl is required when oidc.enabled is true" }}
 {{- end }}
-{{- if .Values.oidc.provider.tokenUrl }}
--Dquine.auth.oidc.full.provider.token-url="{{ .Values.oidc.provider.tokenUrl }}"
+{{- if not .Values.oidc.provider.tokenUrl }}
+{{- fail "oidc.provider.tokenUrl is required when oidc.enabled is true" }}
 {{- end }}
-{{- if .Values.oidc.provider.loginPath }}
--Dquine.auth.oidc.full.provider.login-path="{{ .Values.oidc.provider.loginPath }}"
+{{- if not .Values.oidc.provider.loginPath }}
+{{- fail "oidc.provider.loginPath is required when oidc.enabled is true" }}
 {{- end }}
 {{- if not .Values.oidc.client.existingSecret.name }}
 {{- fail "oidc.client.existingSecret.name is required when oidc.enabled is true" }}
 {{- end }}
+{{- if not .Values.oidc.session.autoGenerate }}
+{{- if not .Values.oidc.session.existingSecret.name }}
+{{- fail "oidc.session.existingSecret.name is required when oidc.enabled is true and autoGenerate is false" }}
+{{- end }}
+{{- if not .Values.oidc.session.existingSecret.key }}
+{{- fail "oidc.session.existingSecret.key is required when oidc.enabled is true and autoGenerate is false" }}
+{{- end }}
+{{- end }}
+-Dquine.auth.oidc.full.provider.location-url="{{ .Values.oidc.provider.locationUrl }}"
+-Dquine.auth.oidc.full.provider.authorization-url="{{ .Values.oidc.provider.authorizationUrl }}"
+-Dquine.auth.oidc.full.provider.token-url="{{ .Values.oidc.provider.tokenUrl }}"
+-Dquine.auth.oidc.full.provider.login-path="{{ .Values.oidc.provider.loginPath }}"
 -Dquine.auth.session.expiration-seconds={{ .Values.oidc.session.expirationSeconds }}
 -Dquine.auth.session.secure-cookies={{ .Values.oidc.session.secureCookies }}
 {{- end }}

--- a/charts/quine-enterprise/templates/_helpers.tpl
+++ b/charts/quine-enterprise/templates/_helpers.tpl
@@ -139,41 +139,9 @@ Cassandra Auth Environment
 {{- end }}
 
 {{/*
-NGINX Basic Auth
-*/}}
-{{- define "quine-enterprise.basicAuth" -}}
-{{- if .Values.basicAuth.enabled }}
-- name: USE_NGINX
-  value: "true"
-- name: USE_BASIC_AUTH
-  value: "true"
-{{- end }}
-{{- end }}
-
-{{/*
-Basic Auth supporting volumes and volume mounts
-*/}}
-{{- define "quine-enterprise.basicAuthVolumes" }}
-{{- if .Values.basicAuth.enabled }}
-- name: credentials-volume
-  secret:
-    secretName: {{ include "quine-enterprise.fullname" . }}-credentials
-{{- end }}
-{{- end }}
-
-{{- define "quine-enterprise.basicAuthVolumeMounts" }}
-{{- if .Values.basicAuth.enabled }}
-- name: credentials-volume
-  readOnly: true
-  mountPath: /credentials
-{{- end }}
-{{- end }}
-
-{{/*
 Liveness and Readiness Probes
 */}}
 {{- define "quine-enterprise.probes" -}}
-{{- if not .Values.basicAuth.enabled }}
 livenessProbe:
   httpGet:
     path: /api/v2/admin/liveness
@@ -186,24 +154,6 @@ readinessProbe:
     port: 8080
   initialDelaySeconds: 5
   timeoutSeconds: 10
-{{- else }}
-livenessProbe:
-  exec:
-    command:
-    - curl
-    - '--silent'
-    - '--fail'
-    - http://localhost:8081/api/v2/admin/liveness
-  initialDelaySeconds: 5
-readinessProbe:
-  exec:
-    command:
-    - curl
-    - '--silent'
-    - '--fail'
-    - http://localhost:8081/api/v2/admin/liveness
-  initialDelaySeconds: 5
-{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/quine-enterprise/templates/_helpers.tpl
+++ b/charts/quine-enterprise/templates/_helpers.tpl
@@ -176,13 +176,13 @@ Liveness and Readiness Probes
 {{- if not .Values.basicAuth.enabled }}
 livenessProbe:
   httpGet:
-    path: /api/v1/admin/liveness
+    path: /api/v2/admin/liveness
     port: 8080
   initialDelaySeconds: 5
   timeoutSeconds: 10
 readinessProbe:
   httpGet:
-    path: /api/v1/admin/liveness
+    path: /api/v2/admin/liveness
     port: 8080
   initialDelaySeconds: 5
   timeoutSeconds: 10
@@ -193,7 +193,7 @@ livenessProbe:
     - curl
     - '--silent'
     - '--fail'
-    - http://localhost:8081/api/v1/admin/liveness
+    - http://localhost:8081/api/v2/admin/liveness
   initialDelaySeconds: 5
 readinessProbe:
   exec:
@@ -201,7 +201,7 @@ readinessProbe:
     - curl
     - '--silent'
     - '--fail'
-    - http://localhost:8081/api/v1/admin/liveness
+    - http://localhost:8081/api/v2/admin/liveness
   initialDelaySeconds: 5
 {{- end }}
 {{- end }}

--- a/charts/quine-enterprise/templates/_helpers.tpl
+++ b/charts/quine-enterprise/templates/_helpers.tpl
@@ -171,13 +171,14 @@ Metrics Configuration Section
 {{- end }}
 
 {{/*
-License Configuration Section
+License Key Secret Validation Section
 */}}
-{{- define "quine-enterprise.licenseConfiguration" -}}
-{{- if .Values.licenseKey }}
--Dquine.license-key={{ .Values.licenseKey }}
-{{- else }}
-{{- fail "licenseKey is required. Please provide a valid license key from thatDot." }}
+{{- define "quine-enterprise.licenseKeyValidation" -}}
+{{- if not .Values.licenseKeySecret.name }}
+{{- fail "licenseKeySecret.name is required. Please provide a valid license key secret from thatDot." }}
+{{- end }}
+{{- if not .Values.licenseKeySecret.key }}
+{{- fail "licenseKeySecret.key is required. Please specify the key containing the license key in the secret." }}
 {{- end }}
 {{- end }}
 

--- a/charts/quine-enterprise/templates/_helpers.tpl
+++ b/charts/quine-enterprise/templates/_helpers.tpl
@@ -248,11 +248,11 @@ OIDC Configuration Section
 {{- if .Values.oidc.provider.loginPath }}
 -Dquine.auth.oidc.full.provider.login-path="{{ .Values.oidc.provider.loginPath }}"
 {{- end }}
-{{- if .Values.oidc.client.id }}
--Dquine.auth.oidc.full.client.id="{{ .Values.oidc.client.id }}"
-{{- end }}
-{{- if .Values.oidc.client.secret }}
--Dquine.auth.oidc.full.client.secret="{{ .Values.oidc.client.secret }}"
+{{- if .Values.oidc.client.existingSecret.name }}
+-Dquine.auth.oidc.full.client.id="${OIDC_CLIENT_ID}"
+-Dquine.auth.oidc.full.client.secret="${OIDC_CLIENT_SECRET}"
+{{- else }}
+{{- fail "oidc.client.existingSecret.name is required when oidc.enabled is true" }}
 {{- end }}
 {{- if .Values.oidc.session.autoGenerate }}
 -Dquine.auth.session.secret="{{ include "quine-enterprise.generateSessionSecret" . }}"

--- a/charts/quine-enterprise/templates/_helpers.tpl
+++ b/charts/quine-enterprise/templates/_helpers.tpl
@@ -254,10 +254,23 @@ OIDC Configuration Section
 {{- if .Values.oidc.client.secret }}
 -Dquine.auth.oidc.full.client.secret="{{ .Values.oidc.client.secret }}"
 {{- end }}
-{{- if .Values.oidc.session.secret }}
+{{- if .Values.oidc.session.autoGenerate }}
+-Dquine.auth.session.secret="{{ include "quine-enterprise.generateSessionSecret" . }}"
+{{- else if .Values.oidc.session.existingSecret.name }}
+-Dquine.auth.session.secret="${OIDC_SESSION_SECRET}"
+{{- else if .Values.oidc.session.secret }}
 -Dquine.auth.session.secret="{{ .Values.oidc.session.secret }}"
 {{- end }}
 -Dquine.auth.session.expiration-seconds={{ .Values.oidc.session.expirationSeconds }}
 -Dquine.auth.session.secure-cookies={{ .Values.oidc.session.secureCookies }}
 {{- end }}
+{{- end }}
+
+{{/*
+Generate a random alphanumeric session secret (32 characters)
+This uses Helm's built-in randAlphaNum function to create a deterministic
+random string that will remain constant for the lifetime of the release.
+*/}}
+{{- define "quine-enterprise.generateSessionSecret" -}}
+{{- randAlphaNum 32 }}
 {{- end }}

--- a/charts/quine-enterprise/templates/_helpers.tpl
+++ b/charts/quine-enterprise/templates/_helpers.tpl
@@ -221,11 +221,12 @@ Metrics Configuration Section
 {{- end }}
 
 {{/*
-Trial Configuration Section
+License Configuration Section
 */}}
-{{- define "quine-enterprise.trialConfiguration" -}}
-{{- if .Values.trial.enabled }}
--Dquine.trial.email={{ required "If trial version is enabled, Values.trial.email must be set" .Values.trial.email }}
--Dquine.trial.api-key={{ required "If trial version is enabled, Values.trial.apiKey must be set" .Values.trial.apiKey }}
+{{- define "quine-enterprise.licenseConfiguration" -}}
+{{- if .Values.licenseKey }}
+-Dquine.license-key={{ .Values.licenseKey }}
+{{- else }}
+{{- fail "licenseKey is required. Please provide a valid license key from thatDot." }}
 {{- end }}
 {{- end }}

--- a/charts/quine-enterprise/templates/_helpers.tpl
+++ b/charts/quine-enterprise/templates/_helpers.tpl
@@ -248,29 +248,11 @@ OIDC Configuration Section
 {{- if .Values.oidc.provider.loginPath }}
 -Dquine.auth.oidc.full.provider.login-path="{{ .Values.oidc.provider.loginPath }}"
 {{- end }}
-{{- if .Values.oidc.client.existingSecret.name }}
--Dquine.auth.oidc.full.client.id="${OIDC_CLIENT_ID}"
--Dquine.auth.oidc.full.client.secret="${OIDC_CLIENT_SECRET}"
-{{- else }}
+{{- if not .Values.oidc.client.existingSecret.name }}
 {{- fail "oidc.client.existingSecret.name is required when oidc.enabled is true" }}
-{{- end }}
-{{- if .Values.oidc.session.autoGenerate }}
--Dquine.auth.session.secret="{{ include "quine-enterprise.generateSessionSecret" . }}"
-{{- else if .Values.oidc.session.existingSecret.name }}
--Dquine.auth.session.secret="${OIDC_SESSION_SECRET}"
-{{- else if .Values.oidc.session.secret }}
--Dquine.auth.session.secret="{{ .Values.oidc.session.secret }}"
 {{- end }}
 -Dquine.auth.session.expiration-seconds={{ .Values.oidc.session.expirationSeconds }}
 -Dquine.auth.session.secure-cookies={{ .Values.oidc.session.secureCookies }}
 {{- end }}
 {{- end }}
 
-{{/*
-Generate a random alphanumeric session secret (32 characters)
-This uses Helm's built-in randAlphaNum function to create a deterministic
-random string that will remain constant for the lifetime of the release.
-*/}}
-{{- define "quine-enterprise.generateSessionSecret" -}}
-{{- randAlphaNum 32 }}
-{{- end }}

--- a/charts/quine-enterprise/templates/basic-auth-secret.yaml
+++ b/charts/quine-enterprise/templates/basic-auth-secret.yaml
@@ -1,9 +1,0 @@
-{{- if .Values.basicAuth.enabled }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "quine-enterprise.fullname" . }}-credentials
-type: Opaque
-data:
-  htpasswd: {{ .Values.basicAuth.htpasswd | b64enc }}
-{{- end }}

--- a/charts/quine-enterprise/templates/deployment.yaml
+++ b/charts/quine-enterprise/templates/deployment.yaml
@@ -55,7 +55,6 @@ spec:
               {{ include "quine-enterprise.persistenceConfiguration" . | nindent 14 }}
               {{ include "quine-enterprise.storeConfiguration" . | nindent 14 }}
               {{ include "quine-enterprise.metricsConfiguration" . | nindent 14 }}
-              {{ include "quine-enterprise.licenseConfiguration" . | nindent 14 }}
               {{ include "quine-enterprise.oidcConfiguration" . | nindent 14 }}
               {{ include "quine-enterprise.prometheusJdkOptions" . | nindent 14 }}
               {{ .Values.extraJdkArgs }}
@@ -87,6 +86,12 @@ spec:
                 key: {{ .Values.oidc.session.existingSecret.key }}
           {{- end }}
           {{- end }}
+          {{ include "quine-enterprise.licenseKeyValidation" . }}
+          - name: CONFIG_FORCE_quine_license__key
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.licenseKeySecret.name }}
+                key: {{ .Values.licenseKeySecret.key }}
           {{ include "quine-enterprise.probes" . | nindent 10 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/quine-enterprise/templates/deployment.yaml
+++ b/charts/quine-enterprise/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
               {{ include "quine-enterprise.persistenceConfiguration" . | nindent 14 }}
               {{ include "quine-enterprise.storeConfiguration" . | nindent 14 }}
               {{ include "quine-enterprise.metricsConfiguration" . | nindent 14 }}
-              {{ include "quine-enterprise.trialConfiguration" . | nindent 14 }}
+              {{ include "quine-enterprise.licenseConfiguration" . | nindent 14 }}
               {{ include "quine-enterprise.prometheusJdkOptions" . | nindent 14 }}
               {{ .Values.extraJdkArgs }}
           {{ include "quine-enterprise.cassandraAuthEnv" . | nindent 10 }}

--- a/charts/quine-enterprise/templates/deployment.yaml
+++ b/charts/quine-enterprise/templates/deployment.yaml
@@ -75,7 +75,10 @@ spec:
           {{- if .Values.oidc.enabled }}
           {{- if .Values.oidc.session.autoGenerate }}
           - name: CONFIG_FORCE_quine_auth_session_secret
-            value: "{{ randAlphaNum 45 }}"
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "quine-enterprise.fullname" . }}-session-secret
+                key: secret
           {{- else if .Values.oidc.session.existingSecret.name }}
           - name: CONFIG_FORCE_quine_auth_session_secret
             valueFrom:

--- a/charts/quine-enterprise/templates/deployment.yaml
+++ b/charts/quine-enterprise/templates/deployment.yaml
@@ -72,6 +72,7 @@ spec:
                 name: {{ .Values.oidc.client.existingSecret.name }}
                 key: {{ .Values.oidc.client.existingSecret.secretKeys.clientSecretKey }}
           {{- end }}
+          {{- if .Values.oidc.enabled }}
           {{- if .Values.oidc.session.autoGenerate }}
           - name: CONFIG_FORCE_quine_auth_session_secret
             value: "{{ randAlphaNum 32 }}"
@@ -81,6 +82,7 @@ spec:
               secretKeyRef:
                 name: {{ .Values.oidc.session.existingSecret.name }}
                 key: {{ .Values.oidc.session.existingSecret.key }}
+          {{- end }}
           {{- end }}
           {{ include "quine-enterprise.probes" . | nindent 10 }}
           resources:

--- a/charts/quine-enterprise/templates/deployment.yaml
+++ b/charts/quine-enterprise/templates/deployment.yaml
@@ -61,6 +61,13 @@ spec:
               {{ .Values.extraJdkArgs }}
           {{ include "quine-enterprise.cassandraAuthEnv" . | nindent 10 }}
           {{ include "quine-enterprise.basicAuth" . | nindent 10 }}
+          {{- if and (not .Values.oidc.session.autoGenerate) .Values.oidc.session.existingSecret.name }}
+          - name: OIDC_SESSION_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.oidc.session.existingSecret.name }}
+                key: {{ .Values.oidc.session.existingSecret.key }}
+          {{- end }}
           {{ include "quine-enterprise.probes" . | nindent 10 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/quine-enterprise/templates/deployment.yaml
+++ b/charts/quine-enterprise/templates/deployment.yaml
@@ -75,7 +75,7 @@ spec:
           {{- if .Values.oidc.enabled }}
           {{- if .Values.oidc.session.autoGenerate }}
           - name: CONFIG_FORCE_quine_auth_session_secret
-            value: "{{ randAlphaNum 32 }}"
+            value: "{{ randAlphaNum 45 }}"
           {{- else if .Values.oidc.session.existingSecret.name }}
           - name: CONFIG_FORCE_quine_auth_session_secret
             valueFrom:

--- a/charts/quine-enterprise/templates/deployment.yaml
+++ b/charts/quine-enterprise/templates/deployment.yaml
@@ -56,6 +56,7 @@ spec:
               {{ include "quine-enterprise.storeConfiguration" . | nindent 14 }}
               {{ include "quine-enterprise.metricsConfiguration" . | nindent 14 }}
               {{ include "quine-enterprise.licenseConfiguration" . | nindent 14 }}
+              {{ include "quine-enterprise.oidcConfiguration" . | nindent 14 }}
               {{ include "quine-enterprise.prometheusJdkOptions" . | nindent 14 }}
               {{ .Values.extraJdkArgs }}
           {{ include "quine-enterprise.cassandraAuthEnv" . | nindent 10 }}

--- a/charts/quine-enterprise/templates/deployment.yaml
+++ b/charts/quine-enterprise/templates/deployment.yaml
@@ -61,24 +61,27 @@ spec:
               {{ .Values.extraJdkArgs }}
           {{ include "quine-enterprise.cassandraAuthEnv" . | nindent 10 }}
           {{ include "quine-enterprise.basicAuth" . | nindent 10 }}
-          {{- if and (not .Values.oidc.session.autoGenerate) .Values.oidc.session.existingSecret.name }}
-          - name: OIDC_SESSION_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.oidc.session.existingSecret.name }}
-                key: {{ .Values.oidc.session.existingSecret.key }}
-          {{- end }}
           {{- if and .Values.oidc.enabled .Values.oidc.client.existingSecret.name }}
-          - name: OIDC_CLIENT_ID
+          - name: CONFIG_FORCE_quine_auth_oidc_full_client_id
             valueFrom:
               secretKeyRef:
                 name: {{ .Values.oidc.client.existingSecret.name }}
                 key: {{ .Values.oidc.client.existingSecret.secretKeys.clientIdKey }}
-          - name: OIDC_CLIENT_SECRET
+          - name: CONFIG_FORCE_quine_auth_oidc_full_client_secret
             valueFrom:
               secretKeyRef:
                 name: {{ .Values.oidc.client.existingSecret.name }}
                 key: {{ .Values.oidc.client.existingSecret.secretKeys.clientSecretKey }}
+          {{- end }}
+          {{- if .Values.oidc.session.autoGenerate }}
+          - name: CONFIG_FORCE_quine_auth_session_secret
+            value: "{{ randAlphaNum 32 }}"
+          {{- else if .Values.oidc.session.existingSecret.name }}
+          - name: CONFIG_FORCE_quine_auth_session_secret
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.oidc.session.existingSecret.name }}
+                key: {{ .Values.oidc.session.existingSecret.key }}
           {{- end }}
           {{ include "quine-enterprise.probes" . | nindent 10 }}
           resources:

--- a/charts/quine-enterprise/templates/deployment.yaml
+++ b/charts/quine-enterprise/templates/deployment.yaml
@@ -60,7 +60,6 @@ spec:
               {{ include "quine-enterprise.prometheusJdkOptions" . | nindent 14 }}
               {{ .Values.extraJdkArgs }}
           {{ include "quine-enterprise.cassandraAuthEnv" . | nindent 10 }}
-          {{ include "quine-enterprise.basicAuth" . | nindent 10 }}
           {{- if and .Values.oidc.enabled .Values.oidc.client.existingSecret.name }}
           - name: CONFIG_FORCE_quine_auth_oidc_full_client_id
             valueFrom:
@@ -90,14 +89,12 @@ spec:
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{ include "quine-enterprise.basicAuthVolumeMounts" . | nindent 12 }}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
       volumes:
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{ include "quine-enterprise.basicAuthVolumes" . | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/quine-enterprise/templates/deployment.yaml
+++ b/charts/quine-enterprise/templates/deployment.yaml
@@ -68,6 +68,18 @@ spec:
                 name: {{ .Values.oidc.session.existingSecret.name }}
                 key: {{ .Values.oidc.session.existingSecret.key }}
           {{- end }}
+          {{- if and .Values.oidc.enabled .Values.oidc.client.existingSecret.name }}
+          - name: OIDC_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.oidc.client.existingSecret.name }}
+                key: {{ .Values.oidc.client.existingSecret.secretKeys.clientIdKey }}
+          - name: OIDC_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.oidc.client.existingSecret.name }}
+                key: {{ .Values.oidc.client.existingSecret.secretKeys.clientSecretKey }}
+          {{- end }}
           {{ include "quine-enterprise.probes" . | nindent 10 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/quine-enterprise/templates/session-secret.yaml
+++ b/charts/quine-enterprise/templates/session-secret.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.oidc.enabled .Values.oidc.session.autoGenerate }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "quine-enterprise.fullname" . }}-session-secret
+  labels:
+    {{- include "quine-enterprise.labels" . | nindent 4 }}
+type: Opaque
+data:
+  secret: {{ randAlphaNum 45 | b64enc | quote }}
+{{- end }}

--- a/charts/quine-enterprise/templates/session-secret.yaml
+++ b/charts/quine-enterprise/templates/session-secret.yaml
@@ -1,11 +1,17 @@
 {{- if and .Values.oidc.enabled .Values.oidc.session.autoGenerate }}
+{{- $secretName := printf "%s-session-secret" (include "quine-enterprise.fullname" .) }}
+{{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace $secretName) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "quine-enterprise.fullname" . }}-session-secret
+  name: {{ $secretName }}
   labels:
     {{- include "quine-enterprise.labels" . | nindent 4 }}
 type: Opaque
 data:
+  {{- if .Release.IsInstall }}
   secret: {{ randAlphaNum 45 | b64enc | quote }}
+  {{- else }}
+  secret: {{ index $existingSecret.data "secret" }}
+  {{- end }}
 {{- end }}

--- a/charts/quine-enterprise/values.yaml
+++ b/charts/quine-enterprise/values.yaml
@@ -132,7 +132,7 @@ oidc:
     locationUrl: ""
     authorizationUrl: ""
     tokenUrl: ""
-    loginPath: "auth"
+    loginPath: ""
   client:
     existingSecret:
       name: "quine-enterprise-oidc-credentials"

--- a/charts/quine-enterprise/values.yaml
+++ b/charts/quine-enterprise/values.yaml
@@ -137,6 +137,10 @@ oidc:
     id: ""
     secret: ""
   session:
+    autoGenerate: true
+    existingSecret:
+      name: ""
+      key: ""
     secret: ""
     expirationSeconds: 3600
     secureCookies: false

--- a/charts/quine-enterprise/values.yaml
+++ b/charts/quine-enterprise/values.yaml
@@ -112,25 +112,38 @@ metrics:
 
 # OIDC Configuration for OpenID Connect authentication
 oidc:
+  # Enable OpenID Connect authentication
   enabled: false
   provider:
+    # OIDC provider base URL
     locationUrl: ""
+    # OAuth2 authorization endpoint for login requests
     authorizationUrl: ""
+    # OAuth2 token endpoint for exchanging auth codes
     tokenUrl: ""
+    # OIDC provider's login endpoint path (appended to locationUrl for user redirect)
     loginPath: ""
   client:
     existingSecret:
+      # Kubernetes secret containing OIDC client credentials
       name: ""
       secretKeys:
+        # Secret key name containing the OIDC client ID
         clientIdKey: "client-id"
+        # Secret key name containing the OIDC client secret
         clientSecretKey: "client-secret"
   session:
+    # Auto-generate session encryption key if no existing secret provided
     autoGenerate: true
     existingSecret:
+      # Kubernetes secret containing session encryption key (if not auto-generating)
       name: ""
+      # Secret key name containing the session encryption key
       key: ""
+    # Session timeout
     expirationSeconds: 3600
-    secureCookies: true
+    # Use HTTPS-only secure cookies for session handling
+    secureCookies: true 
 
 # Override image repository and tag to change the docker image used to run thatDot Quine Enterprise
 # The registry URL and credentials are provided by thatDot with your license key

--- a/charts/quine-enterprise/values.yaml
+++ b/charts/quine-enterprise/values.yaml
@@ -127,7 +127,6 @@ oidc:
     existingSecret:
       name: ""
       key: ""
-    secret: ""
     expirationSeconds: 3600
     secureCookies: true
 

--- a/charts/quine-enterprise/values.yaml
+++ b/charts/quine-enterprise/values.yaml
@@ -108,23 +108,6 @@ metrics:
     # Port opened up on Quine Enterprise pod, exposing Prometheus Java Agent metrics
     port: 9090
 
-# Enable HTTP Basic Authentication for the embedded NGINX reverse‑proxy.
-#
-# `htpasswd` must contain one or more lines in the exact format accepted by the
-# NGINX `auth_basic_user_file` directive:
-#   <username>:<hashed‑password>
-# See the official docs: https://nginx.org/en/docs/http/ngx_http_auth_basic_module.html#auth_basic_user_file
-#
-# Example on how to generate a hashed password:
-#   Creates a salt from 12 random bytes, encoded in base64.
-#   Uses that salt to generate a hashed password using the SHA256-crypt algorithm.
-#
-#   salt=$(openssl rand -base64 12)
-#   openssl passwd -5 -salt $salt
-basicAuth:
-  enabled: false
-  htpasswd: ""
-
 # OIDC Configuration for OpenID Connect authentication
 oidc:
   enabled: false

--- a/charts/quine-enterprise/values.yaml
+++ b/charts/quine-enterprise/values.yaml
@@ -17,7 +17,7 @@ thatdot:
 # License key secret required for Quine Enterprise
 licenseKeySecret:
   name: ""
-  key: ""
+  key: "license-key"
 
 # Cassandra Persistor Settings:
 # Set enabled to true in order to configure the cassandra persistor.

--- a/charts/quine-enterprise/values.yaml
+++ b/charts/quine-enterprise/values.yaml
@@ -118,7 +118,7 @@ oidc:
     loginPath: ""
   client:
     existingSecret:
-      name: "quine-enterprise-oidc-credentials"
+      name: ""
       secretKeys:
         clientIdKey: "client-id"
         clientSecretKey: "client-secret"

--- a/charts/quine-enterprise/values.yaml
+++ b/charts/quine-enterprise/values.yaml
@@ -135,7 +135,7 @@ oidc:
     loginPath: "auth"
   client:
     existingSecret:
-      name: ""
+      name: "quine-enterprise-oidc-credentials"
       secretKeys:
         clientIdKey: "client-id"
         clientSecretKey: "client-secret"

--- a/charts/quine-enterprise/values.yaml
+++ b/charts/quine-enterprise/values.yaml
@@ -14,11 +14,8 @@ thatdot:
   # Possible values: ERROR, WARN, INFO, DEBUG
   logLevel: WARN
 
-# Trial authorization fields. 
-trial:
-  enabled: true
-  email: ""
-  apiKey: ""
+# License key required for Quine Enterprise
+licenseKey: ""
 
 # Cassandra Persistor Settings:
 # Set enabled to true in order to configure the cassandra persistor.
@@ -129,12 +126,14 @@ basicAuth:
   htpasswd: ""
 
 # Override image repository and tag to change the docker image used to run thatDot Quine Enterprise
+# The registry URL and credentials are provided by thatDot with your license key
 image:
-  repository: public.ecr.aws/thatdot/streaming-graph-trial
+  repository: ""
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+# Registry credentials provided by thatDot (e.g., [{"name": "thatdot-registry"}])
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/quine-enterprise/values.yaml
+++ b/charts/quine-enterprise/values.yaml
@@ -14,8 +14,10 @@ thatdot:
   # Possible values: ERROR, WARN, INFO, DEBUG
   logLevel: WARN
 
-# License key required for Quine Enterprise
-licenseKey: ""
+# License key secret required for Quine Enterprise
+licenseKeySecret:
+  name: ""
+  key: ""
 
 # Cassandra Persistor Settings:
 # Set enabled to true in order to configure the cassandra persistor.

--- a/charts/quine-enterprise/values.yaml
+++ b/charts/quine-enterprise/values.yaml
@@ -125,6 +125,22 @@ basicAuth:
   enabled: false
   htpasswd: ""
 
+# OIDC Configuration for OpenID Connect authentication
+oidc:
+  enabled: false
+  provider:
+    locationUrl: ""
+    authorizationUrl: ""
+    tokenUrl: ""
+    loginPath: "auth"
+  client:
+    id: ""
+    secret: ""
+  session:
+    secret: ""
+    expirationSeconds: 3600
+    secureCookies: false
+
 # Override image repository and tag to change the docker image used to run thatDot Quine Enterprise
 # The registry URL and credentials are provided by thatDot with your license key
 image:

--- a/charts/quine-enterprise/values.yaml
+++ b/charts/quine-enterprise/values.yaml
@@ -146,7 +146,7 @@ oidc:
       key: ""
     secret: ""
     expirationSeconds: 3600
-    secureCookies: false
+    secureCookies: true
 
 # Override image repository and tag to change the docker image used to run thatDot Quine Enterprise
 # The registry URL and credentials are provided by thatDot with your license key

--- a/charts/quine-enterprise/values.yaml
+++ b/charts/quine-enterprise/values.yaml
@@ -134,8 +134,11 @@ oidc:
     tokenUrl: ""
     loginPath: "auth"
   client:
-    id: ""
-    secret: ""
+    existingSecret:
+      name: ""
+      secretKeys:
+        clientIdKey: "client-id"
+        clientSecretKey: "client-secret"
   session:
     autoGenerate: true
     existingSecret:

--- a/charts/quine/Chart.yaml
+++ b/charts/quine/Chart.yaml
@@ -3,6 +3,6 @@ name: quine
 description: A Helm chart for creating a thatDot Quine instance
 type: application
 
-version: 0.4.9
+version: 0.5.0
 
 appVersion: "2.0.0"

--- a/charts/quine/Chart.yaml
+++ b/charts/quine/Chart.yaml
@@ -5,4 +5,4 @@ type: application
 
 version: 0.4.9
 
-appVersion: "1.9.3"
+appVersion: "2.0.0"

--- a/extras/example-complete-installation/README.md
+++ b/extras/example-complete-installation/README.md
@@ -10,13 +10,17 @@ Grafana.
 
 ### Prerequisites
 
-* Sign up for Novelty and Quine Enterprise Trial at
-  [thatdot.com](https://www.thatdot.com/free-trial/)
-  * Add email address and API key for Quine Enterprise (also called thatDot
-    Streaming Graph) to quine-enterprise-values.yaml
-  * Add email address and API key for Novelty to novelty-values.yaml
-  * **NOTE:** You will receive the API key via email. A separate key must be
-    used for each unique product.
+* Obtain license keys for Novelty and Quine Enterprise from thatDot
+  * License keys are provided as part of an evaluation agreement or purchase order
+  * To schedule a demo or purchase a license:
+    * Request a demo: [https://www.thatdot.com/request-a-demo/](https://www.thatdot.com/request-a-demo/)
+    * Email sales: [sales@thatdot.com](mailto:sales@thatdot.com)
+    * Contact thatDot: [https://www.thatdot.com/contact-us/](https://www.thatdot.com/contact-us/)
+  * When you receive your license keys, thatDot will also provide:
+    * The private Docker registry URL
+    * Registry credentials
+  * Add license key for Quine Enterprise to quine-enterprise-values.yaml
+  * Add license key for Novelty to novelty-values.yaml
 * Kubernetes cluster (EKS recommended)
   * Clusterrole with permissions to create a new namespace and resources under it.
   * kubectl

--- a/extras/example-complete-installation/install.sh
+++ b/extras/example-complete-installation/install.sh
@@ -36,6 +36,7 @@ helm repo add thatdot https://helm.thatdot.com
 # Novelty Helm chart
 helm upgrade \
     --install \
+    --version 0.4.4 \
     --namespace "$kube_namespace" \
     novelty \
     thatdot/novelty \
@@ -63,6 +64,7 @@ helm upgrade \
 # Quine Enterprise Helm chart
 helm upgrade \
     --install \
+    --version 0.4.9 \
     --namespace "$kube_namespace" \
     quine-enterprise \
     thatdot/quine-enterprise \

--- a/extras/example-complete-installation/novelty-values.yaml
+++ b/extras/example-complete-installation/novelty-values.yaml
@@ -1,4 +1,6 @@
-trial:
-  enabled: true
-  email: ""
-  apiKey: ""
+licenseKey: ""
+
+image:
+  repository: ""
+
+imagePullSecrets: []

--- a/extras/example-complete-installation/quine-enterprise-values.yaml
+++ b/extras/example-complete-installation/quine-enterprise-values.yaml
@@ -1,10 +1,12 @@
 
 hostCount: 3
 
-trial:
-  enabled: true
-  email: ""
-  apiKey: ""
+licenseKey: ""
+
+image:
+  repository: ""
+
+imagePullSecrets: []
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Quine Enterprise and Novelty now require a valid license key to function. This capability is replacing the trial builds for both products. The Helm charts and subsequent documentation is being updated accordingly.

As part of review, please make suggested edits if you see something you know how to fix.