### PR TITLE
QU-2414: Add mTLS helm value configuration

### DIFF
--- a/charts/novelty/Chart.yaml
+++ b/charts/novelty/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: novelty
 description: thatDot Novelty Detector Helm Chart
 
-version: 0.5.0
+version: 0.5.1
 appVersion: 1.0.0

--- a/charts/novelty/templates/_helpers.tpl
+++ b/charts/novelty/templates/_helpers.tpl
@@ -107,3 +107,14 @@ Log Level Configuration Section
 -Dthatdot.loglevel={{ .Values.thatdot.logLevel }}
 {{- end }}
 {{- end }}
+
+{{/*
+Webserver Config Section
+*/}}
+{{- define "novelty.webserverConfiguration" -}}
+-Dthatdot.novelty.webserver.enabled={{ .Values.webserver.enabled }}
+-Dthatdot.novelty.webserver.address={{ .Values.webserver.address }}
+-Dthatdot.novelty.webserver.port={{ .Values.webserver.port }}
+-Dthatdot.novelty.webserver.use-tls={{ .Values.webserver.useTls }}
+-Dthatdot.novelty.webserver.use-m-tls={{ .Values.webserver.useMTls }}
+{{- end }}

--- a/charts/novelty/templates/_helpers.tpl
+++ b/charts/novelty/templates/_helpers.tpl
@@ -116,7 +116,7 @@ Webserver Config Section
 -Dthatdot.novelty.webserver.address={{ .Values.webserver.address }}
 -Dthatdot.novelty.webserver.port={{ .Values.webserver.port }}
 -Dthatdot.novelty.webserver.use-tls={{ .Values.webserver.useTls }}
--Dthatdot.novelty.webserver.use-m-tls={{ .Values.webserver.useMTls }}
+-Dthatdot.novelty.webserver.use-m-tls={{ .Values.webserver.useMTls.enabled }}
 {{- end }}
 
 {{/*

--- a/charts/novelty/templates/_helpers.tpl
+++ b/charts/novelty/templates/_helpers.tpl
@@ -116,7 +116,7 @@ Webserver Config Section
 -Dthatdot.novelty.webserver.address={{ .Values.webserver.address }}
 -Dthatdot.novelty.webserver.port={{ .Values.webserver.port }}
 -Dthatdot.novelty.webserver.use-tls={{ .Values.webserver.useTls }}
--Dthatdot.novelty.webserver.use-m-tls={{ .Values.webserver.useMTls.enabled }}
+-Dthatdot.novelty.webserver.use-mtls.enabled={{ .Values.webserver.useMTls.enabled }}
 {{- end }}
 
 {{/*

--- a/charts/novelty/templates/_helpers.tpl
+++ b/charts/novelty/templates/_helpers.tpl
@@ -121,6 +121,10 @@ Webserver Config Section
 -Dthatdot.novelty.webserver.use-mtls.trust-store.path={{ .Values.webserver.useMTls.trustStore.path }}
 -Dthatdot.novelty.webserver.use-mtls.trust-store.password={{ .Values.webserver.useMTls.trustStore.password }}
 {{- end }}
+{{- if .Values.webserver.useMTls.healthEndpoints }}
+-Dthatdot.novelty.webserver.use-mtls.health-endpoints.enabled={{ .Values.webserver.useMTls.healthEndpoints.enabled }}
+-Dthatdot.novelty.webserver.use-mtls.health-endpoints.port={{ .Values.webserver.useMTls.healthEndpoints.port }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/novelty/templates/_helpers.tpl
+++ b/charts/novelty/templates/_helpers.tpl
@@ -118,3 +118,17 @@ Webserver Config Section
 -Dthatdot.novelty.webserver.use-tls={{ .Values.webserver.useTls }}
 -Dthatdot.novelty.webserver.use-m-tls={{ .Values.webserver.useMTls }}
 {{- end }}
+
+{{/*
+Webserver Advertise Config Section
+*/}}
+{{- define "novelty.webserverAdvertiseConfiguration" -}}
+{{- if .Values.webserverAdvertise.enabled }}
+{{- if .Values.webserverAdvertise.address }}
+-Dthatdot.novelty.webserver-advertise.address={{ .Values.webserverAdvertise.address }}
+{{- end }}
+{{- if .Values.webserverAdvertise.port }}
+-Dthatdot.novelty.webserver-advertise.port={{ .Values.webserverAdvertise.port }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/novelty/templates/_helpers.tpl
+++ b/charts/novelty/templates/_helpers.tpl
@@ -117,6 +117,10 @@ Webserver Config Section
 -Dthatdot.novelty.webserver.port={{ .Values.webserver.port }}
 -Dthatdot.novelty.webserver.use-tls={{ .Values.webserver.useTls }}
 -Dthatdot.novelty.webserver.use-mtls.enabled={{ .Values.webserver.useMTls.enabled }}
+{{- if and .Values.webserver.useMTls.trustStore .Values.webserver.useMTls.trustStore.path .Values.webserver.useMTls.trustStore.password }}
+-Dthatdot.novelty.webserver.use-mtls.trust-store.path={{ .Values.webserver.useMTls.trustStore.path }}
+-Dthatdot.novelty.webserver.use-mtls.trust-store.password={{ .Values.webserver.useMTls.trustStore.password }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/novelty/templates/deployment.yaml
+++ b/charts/novelty/templates/deployment.yaml
@@ -30,6 +30,7 @@ spec:
               {{ include "novelty.logLevelConfiguration" . | nindent 14 }}
               {{ include "novelty.oidcConfiguration" . | nindent 14 }}
               {{ include "novelty.metricsJdkOptions" . | nindent 14 }}
+              {{ include "novelty.webserverConfiguration" . | nindent 14 }}
               {{ include "novelty.jmxJdkOptions" . | nindent 14 }}
               {{ include "novelty.prometheusJdkOptions" . | nindent 14 }}
               {{ .Values.extraJdkArgs }}
@@ -72,11 +73,17 @@ spec:
             httpGet:
               path: /api/v2/admin/liveness
               port: 8080
+              {{- if .Values.webserver.useTls }}
+              scheme: HTTPS
+              {{- end }}
             initialDelaySeconds: 5
           readinessProbe:
             httpGet:
               path: /api/v2/admin/liveness
               port: 8080
+              {{- if .Values.webserver.useTls }}
+              scheme: HTTPS
+              {{- end }}
             initialDelaySeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/novelty/templates/deployment.yaml
+++ b/charts/novelty/templates/deployment.yaml
@@ -73,16 +73,18 @@ spec:
           {{- if .Values.webserver.useMTls.enabled }}
           {{- if .Values.webserver.useMTls.healthEndpoints.enabled }}
           livenessProbe:
-            httpGet:
-              path: /api/v2/admin/liveness
-              port: {{ .Values.webserver.useMTls.healthEndpoints.port }}
-              host: 127.0.0.1
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent -f -o /dev/null http://127.0.0.1:{{ .Values.webserver.useMTls.healthEndpoints.port }}/api/v2/admin/liveness
             initialDelaySeconds: 5
           readinessProbe:
-            httpGet:
-              path: /api/v2/admin/liveness
-              port: {{ .Values.webserver.useMTls.healthEndpoints.port }}
-              host: 127.0.0.1
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent -f -o /dev/null http://127.0.0.1:{{ .Values.webserver.useMTls.healthEndpoints.port }}/api/v2/admin/liveness
             initialDelaySeconds: 5
           {{- end }}
           {{- else }}

--- a/charts/novelty/templates/deployment.yaml
+++ b/charts/novelty/templates/deployment.yaml
@@ -31,6 +31,7 @@ spec:
               {{ include "novelty.oidcConfiguration" . | nindent 14 }}
               {{ include "novelty.metricsJdkOptions" . | nindent 14 }}
               {{ include "novelty.webserverConfiguration" . | nindent 14 }}
+              {{ include "novelty.webserverAdvertiseConfiguration" . | nindent 14 }}
               {{ include "novelty.jmxJdkOptions" . | nindent 14 }}
               {{ include "novelty.prometheusJdkOptions" . | nindent 14 }}
               {{ .Values.extraJdkArgs }}

--- a/charts/novelty/templates/deployment.yaml
+++ b/charts/novelty/templates/deployment.yaml
@@ -70,20 +70,23 @@ spec:
                 key: {{ .Values.licenseKeySecret.key }}
           ports:
           - containerPort: {{ .Values.service.internalPort }}
-          {{- if .Values.webserver.useMTls }}
+          {{- if .Values.webserver.useMTls.enabled }}
+          {{- if not .Values.webserver.useMTls.clientCertificateConfigMap }}
+          {{- fail "webserver.useMTls.enabled is true but clientCertificateConfigMap is not set" }}
+          {{- end }}
           livenessProbe:
             exec:
               command:
                 - /bin/sh
                 - -c
-                - curl --cacert /certs/ca.pem --cert /certs/client.pem --key /certs/client-key.pem --silent -v https://localhost:8080/api/v2/admin/liveness
+                - curl --cacert /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}/ca.pem --cert /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}/client.pem --key /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}/client-key.pem --silent -f -o /dev/null https://localhost:8080/api/v2/admin/liveness
             initialDelaySeconds: 5
           readinessProbe:
             exec:
               command:
                 - /bin/sh
                 - -c
-                - curl --cacert /certs/ca.pem --cert /certs/client.pem --key /certs/client-key.pem --silent -v https://localhost:8080/api/v2/admin/liveness
+                - curl --cacert /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}/ca.pem --cert /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}/client.pem --key /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}/client-key.pem --silent -f -o /dev/null https://localhost:8080/api/v2/admin/liveness
             initialDelaySeconds: 5
           {{- else }}
           livenessProbe:
@@ -109,37 +112,24 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.webserver.useMTls }}
+          {{- if .Values.webserver.useMTls.enabled }}
           {{- if not .Values.volumeMounts }}
           volumeMounts:
           {{- end }}
-            - name: ca-certificates
-              mountPath: /certs/ca.pem
-              subPath: ca.pem
-              readOnly: true
-            - name: client-certificates
-              mountPath: /certs/client.pem
-              subPath: client.pem
-              readOnly: true
-            - name: client-certificates
-              mountPath: /certs/client-key.pem
-              subPath: client-key.pem
+            - name: tls-certificates
+              mountPath: /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}
               readOnly: true
           {{- end }}
       {{- with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.webserver.useMTls }}
+      {{- if .Values.webserver.useMTls.enabled }}
       {{- if not .Values.volumes }}
       volumes:
       {{- end }}
-        - name: ca-certificates
+        - name: tls-certificates
           configMap:
-            name: ca-certificates
-            defaultMode: 0444
-        - name: client-certificates
-          configMap:
-            name: client-certificates
+            name: {{ .Values.webserver.useMTls.clientCertificateConfigMap }}
             defaultMode: 0444
       {{- end }}

--- a/charts/novelty/templates/deployment.yaml
+++ b/charts/novelty/templates/deployment.yaml
@@ -71,23 +71,20 @@ spec:
           ports:
           - containerPort: {{ .Values.service.internalPort }}
           {{- if .Values.webserver.useMTls.enabled }}
-          {{- if not .Values.webserver.useMTls.clientCertificateConfigMap }}
-          {{- fail "webserver.useMTls.enabled is true but clientCertificateConfigMap is not set" }}
-          {{- end }}
+          {{- if .Values.webserver.useMTls.healthEndpoints.enabled }}
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - curl --cacert /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}/ca.pem --cert /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}/client.pem --key /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}/client-key.pem --silent -f -o /dev/null https://localhost:8080/api/v2/admin/liveness
+            httpGet:
+              path: /api/v2/admin/liveness
+              port: {{ .Values.webserver.useMTls.healthEndpoints.port }}
+              host: 127.0.0.1
             initialDelaySeconds: 5
           readinessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - curl --cacert /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}/ca.pem --cert /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}/client.pem --key /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}/client-key.pem --silent -f -o /dev/null https://localhost:8080/api/v2/admin/liveness
+            httpGet:
+              path: /api/v2/admin/liveness
+              port: {{ .Values.webserver.useMTls.healthEndpoints.port }}
+              host: 127.0.0.1
             initialDelaySeconds: 5
+          {{- end }}
           {{- else }}
           livenessProbe:
             httpGet:
@@ -112,24 +109,7 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.webserver.useMTls.enabled }}
-          {{- if not .Values.volumeMounts }}
-          volumeMounts:
-          {{- end }}
-            - name: tls-certificates
-              mountPath: /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}
-              readOnly: true
-          {{- end }}
       {{- with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- if .Values.webserver.useMTls.enabled }}
-      {{- if not .Values.volumes }}
-      volumes:
-      {{- end }}
-        - name: tls-certificates
-          configMap:
-            name: {{ .Values.webserver.useMTls.clientCertificateConfigMap }}
-            defaultMode: 0444
       {{- end }}

--- a/charts/novelty/templates/deployment.yaml
+++ b/charts/novelty/templates/deployment.yaml
@@ -70,6 +70,22 @@ spec:
                 key: {{ .Values.licenseKeySecret.key }}
           ports:
           - containerPort: {{ .Values.service.internalPort }}
+          {{- if .Values.webserver.useMTls }}
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --cacert /certs/ca.pem --cert /certs/client.pem --key /certs/client-key.pem --silent -v https://localhost:8080/api/v2/admin/liveness
+            initialDelaySeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --cacert /certs/ca.pem --cert /certs/client.pem --key /certs/client-key.pem --silent -v https://localhost:8080/api/v2/admin/liveness
+            initialDelaySeconds: 5
+          {{- else }}
           livenessProbe:
             httpGet:
               path: /api/v2/admin/liveness
@@ -86,13 +102,44 @@ spec:
               scheme: HTTPS
               {{- end }}
             initialDelaySeconds: 5
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.webserver.useMTls }}
+          {{- if not .Values.volumeMounts }}
+          volumeMounts:
+          {{- end }}
+            - name: ca-certificates
+              mountPath: /certs/ca.pem
+              subPath: ca.pem
+              readOnly: true
+            - name: client-certificates
+              mountPath: /certs/client.pem
+              subPath: client.pem
+              readOnly: true
+            - name: client-certificates
+              mountPath: /certs/client-key.pem
+              subPath: client-key.pem
+              readOnly: true
+          {{- end }}
       {{- with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.webserver.useMTls }}
+      {{- if not .Values.volumes }}
+      volumes:
+      {{- end }}
+        - name: ca-certificates
+          configMap:
+            name: ca-certificates
+            defaultMode: 0444
+        - name: client-certificates
+          configMap:
+            name: client-certificates
+            defaultMode: 0444
       {{- end }}

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -116,7 +116,9 @@ webserver:
   address: 0.0.0.0
   port: 8080
   useTls: false
-  useMTls: false
+  useMTls:
+    enabled: false
+    clientCertificateConfigMap: ""
 
 webserverAdvertise:
   enabled: false
@@ -124,9 +126,19 @@ webserverAdvertise:
   port:
 
 # mTLS Configuration
-# When webserver.useMTls is enabled, the following ConfigMaps must be created in the cluster:
-# - ca-certificates: Contains the CA certificate in PEM format with key 'ca.pem'
-# - client-certificates: Contains client certificate and key with keys 'client.pem' and 'client-key.pem'
+# When webserver.useMTls.enabled is true, a ConfigMap containing client certificates must be specified.
+# The ConfigMap should contain three files in PEM format:
+# - ca.pem: CA certificate for verifying the server
+# - client.pem: Client certificate for mTLS authentication
+# - client-key.pem: Client private key for mTLS authentication
+#
+# Example ConfigMap creation:
+#   kubectl create configmap my-tls-certs \
+#     --from-file=ca.pem=path/to/ca.pem \
+#     --from-file=client.pem=path/to/client.pem \
+#     --from-file=client-key.pem=path/to/client-key.pem
+#
+# Then set: webserver.useMTls.clientCertificateConfigMap: my-tls-certs
 
 # Whitespace-separated jdk arguments injected via JAVA_JDK_OPTIONS
 extraJdkArgs: ""

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -118,7 +118,9 @@ webserver:
   useTls: false
   useMTls:
     enabled: false
-    clientCertificateConfigMap: ""
+    healthEndpoints:
+      enabled: false
+      port: 8081
     # trustStore:
     #   path: ""
     #   password: ""
@@ -129,19 +131,10 @@ webserverAdvertise:
   port:
 
 # mTLS Configuration
-# When webserver.useMTls.enabled is true, a ConfigMap containing client certificates must be specified.
-# The ConfigMap should contain three files in PEM format:
-# - ca.pem: CA certificate for verifying the server
-# - client.pem: Client certificate for mTLS authentication
-# - client-key.pem: Client private key for mTLS authentication
-#
-# Example ConfigMap creation:
-#   kubectl create configmap my-tls-certs \
-#     --from-file=ca.pem=path/to/ca.pem \
-#     --from-file=client.pem=path/to/client.pem \
-#     --from-file=client-key.pem=path/to/client-key.pem
-#
-# Then set: webserver.useMTls.clientCertificateConfigMap: my-tls-certs
+# When webserver.useMTls.enabled is true:
+# - If healthEndpoints.enabled is true, health probes will use HTTP on the loopback
+#   address with the configured healthEndpoints.port
+# - If healthEndpoints.enabled is false, health probes will be disabled
 
 # Whitespace-separated jdk arguments injected via JAVA_JDK_OPTIONS
 extraJdkArgs: ""

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -118,5 +118,10 @@ webserver:
   useTls: false
   useMTls: false
 
+webserverAdvertise:
+  enabled: false
+  address:
+  port:
+
 # Whitespace-separated jdk arguments injected via JAVA_JDK_OPTIONS
 extraJdkArgs: ""

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -119,6 +119,9 @@ webserver:
   useMTls:
     enabled: false
     clientCertificateConfigMap: ""
+    # trustStore:
+    #   path: ""
+    #   password: ""
 
 webserverAdvertise:
   enabled: false

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -111,5 +111,12 @@ thatdot:
   # Cluster-wide log level (ERROR, WARN, INFO, DEBUG)
   logLevel: WARN
 
+webserver:
+  enabled: true
+  address: 0.0.0.0
+  port: 8080
+  useTls: false
+  useMTls: false
+
 # Whitespace-separated jdk arguments injected via JAVA_JDK_OPTIONS
 extraJdkArgs: ""

--- a/charts/novelty/values.yaml
+++ b/charts/novelty/values.yaml
@@ -123,5 +123,10 @@ webserverAdvertise:
   address:
   port:
 
+# mTLS Configuration
+# When webserver.useMTls is enabled, the following ConfigMaps must be created in the cluster:
+# - ca-certificates: Contains the CA certificate in PEM format with key 'ca.pem'
+# - client-certificates: Contains client certificate and key with keys 'client.pem' and 'client-key.pem'
+
 # Whitespace-separated jdk arguments injected via JAVA_JDK_OPTIONS
 extraJdkArgs: ""

--- a/charts/quine-enterprise/Chart.yaml
+++ b/charts/quine-enterprise/Chart.yaml
@@ -3,6 +3,6 @@ name: quine-enterprise
 description: A Helm chart for creating a thatDot Quine Enterprise cluster
 type: application
 
-version: 0.5.0
+version: 0.5.1
 
 appVersion: "2.0.0"

--- a/charts/quine-enterprise/templates/_helpers.tpl
+++ b/charts/quine-enterprise/templates/_helpers.tpl
@@ -167,6 +167,24 @@ Cassandra Auth Environment
 Liveness and Readiness Probes
 */}}
 {{- define "quine-enterprise.probes" -}}
+{{- if .Values.webserver.useMTls }}
+livenessProbe:
+  exec:
+    command:
+      - /bin/sh
+      - -c
+      - curl --cacert /certs/ca.pem --cert /certs/client.pem --key /certs/client-key.pem --silent -f -o /dev/null https://localhost:8080/api/v2/admin/liveness
+  initialDelaySeconds: 5
+  timeoutSeconds: 10
+readinessProbe:
+  exec:
+    command:
+      - /bin/sh
+      - -c
+      - curl --cacert /certs/ca.pem --cert /certs/client.pem --key /certs/client-key.pem --silent -f -o /dev/null https://localhost:8080/api/v2/admin/liveness
+  initialDelaySeconds: 5
+  timeoutSeconds: 10
+{{- else }}
 livenessProbe:
   httpGet:
     path: /api/v2/admin/liveness
@@ -185,6 +203,7 @@ readinessProbe:
     {{- end }}
   initialDelaySeconds: 5
   timeoutSeconds: 10
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/quine-enterprise/templates/_helpers.tpl
+++ b/charts/quine-enterprise/templates/_helpers.tpl
@@ -105,6 +105,20 @@ Webserver Config Section
 {{- end }}
 
 {{/*
+Webserver Advertise Config Section
+*/}}
+{{- define "quine-enterprise.webserverAdvertiseConfiguration" -}}
+{{- if .Values.webserverAdvertise.enabled }}
+{{- if .Values.webserverAdvertise.address }}
+-Dquine.webserver-advertise.address={{ .Values.webserverAdvertise.address }}
+{{- end }}
+{{- if .Values.webserverAdvertise.port }}
+-Dquine.webserver-advertise.port={{ .Values.webserverAdvertise.port }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 Store Config Section
 */}}
 {{- define "quine-enterprise.storeConfiguration" -}}

--- a/charts/quine-enterprise/templates/_helpers.tpl
+++ b/charts/quine-enterprise/templates/_helpers.tpl
@@ -94,6 +94,17 @@ Persistence Config Section
 {{- end }}
 
 {{/*
+Webserver Config Section
+*/}}
+{{- define "quine-enterprise.webserverConfiguration" -}}
+-Dquine.webserver.enabled={{ .Values.webserver.enabled }}
+-Dquine.webserver.address={{ .Values.webserver.address }}
+-Dquine.webserver.port={{ .Values.webserver.port }}
+-Dquine.webserver.use-tls={{ .Values.webserver.useTls }}
+-Dquine.webserver.use-m-tls={{ .Values.webserver.useMTls }}
+{{- end }}
+
+{{/*
 Store Config Section
 */}}
 {{- define "quine-enterprise.storeConfiguration" -}}
@@ -146,12 +157,18 @@ livenessProbe:
   httpGet:
     path: /api/v2/admin/liveness
     port: 8080
+    {{- if .Values.webserver.useTls }}
+    scheme: HTTPS
+    {{- end }}
   initialDelaySeconds: 5
   timeoutSeconds: 10
 readinessProbe:
   httpGet:
     path: /api/v2/admin/liveness
     port: 8080
+    {{- if .Values.webserver.useTls }}
+    scheme: HTTPS
+    {{- end }}
   initialDelaySeconds: 5
   timeoutSeconds: 10
 {{- end }}

--- a/charts/quine-enterprise/templates/_helpers.tpl
+++ b/charts/quine-enterprise/templates/_helpers.tpl
@@ -178,17 +178,19 @@ Liveness and Readiness Probes
 {{- if .Values.webserver.useMTls.enabled }}
 {{- if .Values.webserver.useMTls.healthEndpoints.enabled }}
 livenessProbe:
-  httpGet:
-    path: /api/v2/admin/liveness
-    port: {{ .Values.webserver.useMTls.healthEndpoints.port }}
-    host: 127.0.0.1
+  exec:
+    command:
+      - /bin/sh
+      - -c
+      - curl --silent -f -o /dev/null http://127.0.0.1:{{ .Values.webserver.useMTls.healthEndpoints.port }}/api/v2/admin/liveness
   initialDelaySeconds: 5
   timeoutSeconds: 10
 readinessProbe:
-  httpGet:
-    path: /api/v2/admin/liveness
-    port: {{ .Values.webserver.useMTls.healthEndpoints.port }}
-    host: 127.0.0.1
+  exec:
+    command:
+      - /bin/sh
+      - -c
+      - curl --silent -f -o /dev/null http://127.0.0.1:{{ .Values.webserver.useMTls.healthEndpoints.port }}/api/v2/admin/liveness
   initialDelaySeconds: 5
   timeoutSeconds: 10
 {{- end }}

--- a/charts/quine-enterprise/templates/_helpers.tpl
+++ b/charts/quine-enterprise/templates/_helpers.tpl
@@ -101,7 +101,7 @@ Webserver Config Section
 -Dquine.webserver.address={{ .Values.webserver.address }}
 -Dquine.webserver.port={{ .Values.webserver.port }}
 -Dquine.webserver.use-tls={{ .Values.webserver.useTls }}
--Dquine.webserver.use-m-tls={{ .Values.webserver.useMTls.enabled }}
+-Dquine.webserver.use-mtls.enabled={{ .Values.webserver.useMTls.enabled }}
 {{- end }}
 
 {{/*

--- a/charts/quine-enterprise/templates/_helpers.tpl
+++ b/charts/quine-enterprise/templates/_helpers.tpl
@@ -102,6 +102,10 @@ Webserver Config Section
 -Dquine.webserver.port={{ .Values.webserver.port }}
 -Dquine.webserver.use-tls={{ .Values.webserver.useTls }}
 -Dquine.webserver.use-mtls.enabled={{ .Values.webserver.useMTls.enabled }}
+{{- if and .Values.webserver.useMTls.trustStore .Values.webserver.useMTls.trustStore.path .Values.webserver.useMTls.trustStore.password }}
+-Dquine.webserver.use-mtls.trust-store.path={{ .Values.webserver.useMTls.trustStore.path }}
+-Dquine.webserver.use-mtls.trust-store.password={{ .Values.webserver.useMTls.trustStore.password }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/quine-enterprise/templates/_helpers.tpl
+++ b/charts/quine-enterprise/templates/_helpers.tpl
@@ -101,7 +101,7 @@ Webserver Config Section
 -Dquine.webserver.address={{ .Values.webserver.address }}
 -Dquine.webserver.port={{ .Values.webserver.port }}
 -Dquine.webserver.use-tls={{ .Values.webserver.useTls }}
--Dquine.webserver.use-m-tls={{ .Values.webserver.useMTls }}
+-Dquine.webserver.use-m-tls={{ .Values.webserver.useMTls.enabled }}
 {{- end }}
 
 {{/*
@@ -167,13 +167,16 @@ Cassandra Auth Environment
 Liveness and Readiness Probes
 */}}
 {{- define "quine-enterprise.probes" -}}
-{{- if .Values.webserver.useMTls }}
+{{- if .Values.webserver.useMTls.enabled }}
+{{- if not .Values.webserver.useMTls.clientCertificateConfigMap }}
+{{- fail "webserver.useMTls.enabled is true but clientCertificateConfigMap is not set" }}
+{{- end }}
 livenessProbe:
   exec:
     command:
       - /bin/sh
       - -c
-      - curl --cacert /certs/ca.pem --cert /certs/client.pem --key /certs/client-key.pem --silent -f -o /dev/null https://localhost:8080/api/v2/admin/liveness
+      - curl --cacert /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}/ca.pem --cert /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}/client.pem --key /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}/client-key.pem --silent -f -o /dev/null https://localhost:8080/api/v2/admin/liveness
   initialDelaySeconds: 5
   timeoutSeconds: 10
 readinessProbe:
@@ -181,7 +184,7 @@ readinessProbe:
     command:
       - /bin/sh
       - -c
-      - curl --cacert /certs/ca.pem --cert /certs/client.pem --key /certs/client-key.pem --silent -f -o /dev/null https://localhost:8080/api/v2/admin/liveness
+      - curl --cacert /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}/ca.pem --cert /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}/client.pem --key /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}/client-key.pem --silent -f -o /dev/null https://localhost:8080/api/v2/admin/liveness
   initialDelaySeconds: 5
   timeoutSeconds: 10
 {{- else }}

--- a/charts/quine-enterprise/templates/deployment.yaml
+++ b/charts/quine-enterprise/templates/deployment.yaml
@@ -101,11 +101,35 @@ spec:
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- if .Values.webserver.useMTls }}
+            - name: ca-certificates
+              mountPath: /certs/ca.pem
+              subPath: ca.pem
+              readOnly: true
+            - name: client-certificates
+              mountPath: /certs/client.pem
+              subPath: client.pem
+              readOnly: true
+            - name: client-certificates
+              mountPath: /certs/client-key.pem
+              subPath: client-key.pem
+              readOnly: true
+            {{- end }}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
       volumes:
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.webserver.useMTls }}
+        - name: ca-certificates
+          configMap:
+            name: ca-certificates
+            defaultMode: 0444
+        - name: client-certificates
+          configMap:
+            name: client-certificates
+            defaultMode: 0444
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/quine-enterprise/templates/deployment.yaml
+++ b/charts/quine-enterprise/templates/deployment.yaml
@@ -55,6 +55,7 @@ spec:
               {{ include "quine-enterprise.persistenceConfiguration" . | nindent 14 }}
               {{ include "quine-enterprise.storeConfiguration" . | nindent 14 }}
               {{ include "quine-enterprise.metricsConfiguration" . | nindent 14 }}
+              {{ include "quine-enterprise.webserverConfiguration" . | nindent 14 }}
               {{ include "quine-enterprise.oidcConfiguration" . | nindent 14 }}
               {{ include "quine-enterprise.prometheusJdkOptions" . | nindent 14 }}
               {{ .Values.extraJdkArgs }}

--- a/charts/quine-enterprise/templates/deployment.yaml
+++ b/charts/quine-enterprise/templates/deployment.yaml
@@ -56,6 +56,7 @@ spec:
               {{ include "quine-enterprise.storeConfiguration" . | nindent 14 }}
               {{ include "quine-enterprise.metricsConfiguration" . | nindent 14 }}
               {{ include "quine-enterprise.webserverConfiguration" . | nindent 14 }}
+              {{ include "quine-enterprise.webserverAdvertiseConfiguration" . | nindent 14 }}
               {{ include "quine-enterprise.oidcConfiguration" . | nindent 14 }}
               {{ include "quine-enterprise.prometheusJdkOptions" . | nindent 14 }}
               {{ .Values.extraJdkArgs }}

--- a/charts/quine-enterprise/templates/deployment.yaml
+++ b/charts/quine-enterprise/templates/deployment.yaml
@@ -101,18 +101,9 @@ spec:
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{- if .Values.webserver.useMTls }}
-            - name: ca-certificates
-              mountPath: /certs/ca.pem
-              subPath: ca.pem
-              readOnly: true
-            - name: client-certificates
-              mountPath: /certs/client.pem
-              subPath: client.pem
-              readOnly: true
-            - name: client-certificates
-              mountPath: /certs/client-key.pem
-              subPath: client-key.pem
+            {{- if .Values.webserver.useMTls.enabled }}
+            - name: tls-certificates
+              mountPath: /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}
               readOnly: true
             {{- end }}
           terminationMessagePath: /dev/termination-log
@@ -121,14 +112,10 @@ spec:
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- if .Values.webserver.useMTls }}
-        - name: ca-certificates
+        {{- if .Values.webserver.useMTls.enabled }}
+        - name: tls-certificates
           configMap:
-            name: ca-certificates
-            defaultMode: 0444
-        - name: client-certificates
-          configMap:
-            name: client-certificates
+            name: {{ .Values.webserver.useMTls.clientCertificateConfigMap }}
             defaultMode: 0444
         {{- end }}
       {{- with .Values.nodeSelector }}

--- a/charts/quine-enterprise/templates/deployment.yaml
+++ b/charts/quine-enterprise/templates/deployment.yaml
@@ -101,22 +101,11 @@ spec:
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{- if .Values.webserver.useMTls.enabled }}
-            - name: tls-certificates
-              mountPath: /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}
-              readOnly: true
-            {{- end }}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
       volumes:
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- if .Values.webserver.useMTls.enabled }}
-        - name: tls-certificates
-          configMap:
-            name: {{ .Values.webserver.useMTls.clientCertificateConfigMap }}
-            defaultMode: 0444
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/quine-enterprise/values.yaml
+++ b/charts/quine-enterprise/values.yaml
@@ -31,6 +31,14 @@ webserverAdvertise:
   address:
   port:
 
+# mTLS Configuration
+# When webserver.useMTls is enabled, the following ConfigMaps must be created in the cluster:
+# - ca-certificates: Contains the CA certificate in PEM format with key 'ca.pem'
+# - client-certificates: Contains client certificate and key with keys 'client.pem' and 'client-key.pem'
+#
+# These are automatically mounted when useMTls is true.
+# The install script in the pentesting directory can create these ConfigMaps from JKS keystores.
+
 # Cassandra Persistor Settings:
 # Set enabled to true in order to configure the cassandra persistor.
 # NOTE: For now the cassandra persistor is the only one supported by this

--- a/charts/quine-enterprise/values.yaml
+++ b/charts/quine-enterprise/values.yaml
@@ -26,6 +26,9 @@ webserver:
   useTls: false
   useMTls:
     enabled: false
+    # trustStore:
+    #   path: ""
+    #   password: ""
     clientCertificateConfigMap: ""
 
 webserverAdvertise:

--- a/charts/quine-enterprise/values.yaml
+++ b/charts/quine-enterprise/values.yaml
@@ -24,7 +24,9 @@ webserver:
   address: 0.0.0.0
   port: 8080
   useTls: false
-  useMTls: false
+  useMTls:
+    enabled: false
+    clientCertificateConfigMap: ""
 
 webserverAdvertise:
   enabled: false
@@ -32,12 +34,19 @@ webserverAdvertise:
   port:
 
 # mTLS Configuration
-# When webserver.useMTls is enabled, the following ConfigMaps must be created in the cluster:
-# - ca-certificates: Contains the CA certificate in PEM format with key 'ca.pem'
-# - client-certificates: Contains client certificate and key with keys 'client.pem' and 'client-key.pem'
+# When webserver.useMTls.enabled is true, a ConfigMap containing client certificates must be specified.
+# The ConfigMap should contain three files in PEM format:
+# - ca.pem: CA certificate for verifying the server
+# - client.pem: Client certificate for mTLS authentication
+# - client-key.pem: Client private key for mTLS authentication
 #
-# These are automatically mounted when useMTls is true.
-# The install script in the pentesting directory can create these ConfigMaps from JKS keystores.
+# Example ConfigMap creation:
+#   kubectl create configmap my-tls-certs \
+#     --from-file=ca.pem=path/to/ca.pem \
+#     --from-file=client.pem=path/to/client.pem \
+#     --from-file=client-key.pem=path/to/client-key.pem
+#
+# Then set: webserver.useMTls.clientCertificateConfigMap: my-tls-certs
 
 # Cassandra Persistor Settings:
 # Set enabled to true in order to configure the cassandra persistor.

--- a/charts/quine-enterprise/values.yaml
+++ b/charts/quine-enterprise/values.yaml
@@ -26,6 +26,11 @@ webserver:
   useTls: false
   useMTls: false
 
+webserverAdvertise:
+  enabled: false
+  address:
+  port:
+
 # Cassandra Persistor Settings:
 # Set enabled to true in order to configure the cassandra persistor.
 # NOTE: For now the cassandra persistor is the only one supported by this

--- a/charts/quine-enterprise/values.yaml
+++ b/charts/quine-enterprise/values.yaml
@@ -29,7 +29,9 @@ webserver:
     # trustStore:
     #   path: ""
     #   password: ""
-    clientCertificateConfigMap: ""
+    healthEndpoints:
+      enabled: false
+      port: 8081
 
 webserverAdvertise:
   enabled: false
@@ -37,19 +39,10 @@ webserverAdvertise:
   port:
 
 # mTLS Configuration
-# When webserver.useMTls.enabled is true, a ConfigMap containing client certificates must be specified.
-# The ConfigMap should contain three files in PEM format:
-# - ca.pem: CA certificate for verifying the server
-# - client.pem: Client certificate for mTLS authentication
-# - client-key.pem: Client private key for mTLS authentication
-#
-# Example ConfigMap creation:
-#   kubectl create configmap my-tls-certs \
-#     --from-file=ca.pem=path/to/ca.pem \
-#     --from-file=client.pem=path/to/client.pem \
-#     --from-file=client-key.pem=path/to/client-key.pem
-#
-# Then set: webserver.useMTls.clientCertificateConfigMap: my-tls-certs
+# When webserver.useMTls.enabled is true:
+# - If healthEndpoints.enabled is true, health probes will use HTTP on the loopback
+#   address with the configured healthEndpoints.port
+# - If healthEndpoints.enabled is false, health probes will be disabled
 
 # Cassandra Persistor Settings:
 # Set enabled to true in order to configure the cassandra persistor.

--- a/charts/quine-enterprise/values.yaml
+++ b/charts/quine-enterprise/values.yaml
@@ -19,6 +19,13 @@ licenseKeySecret:
   name: ""
   key: "license-key"
 
+webserver:
+  enabled: true
+  address: 0.0.0.0
+  port: 8080
+  useTls: false
+  useMTls: false
+
 # Cassandra Persistor Settings:
 # Set enabled to true in order to configure the cassandra persistor.
 # NOTE: For now the cassandra persistor is the only one supported by this

--- a/charts/quine/Chart.yaml
+++ b/charts/quine/Chart.yaml
@@ -3,6 +3,6 @@ name: quine
 description: A Helm chart for creating a thatDot Quine instance
 type: application
 
-version: 0.5.0
+version: 0.5.1
 
 appVersion: "2.0.0"

--- a/charts/quine/templates/_helpers.tpl
+++ b/charts/quine/templates/_helpers.tpl
@@ -73,6 +73,17 @@ Persistence Config Section
 {{- end }}
 
 {{/*
+Webserver Config Section
+*/}}
+{{- define "quine.webserverConfiguration" -}}
+-Dquine.webserver.enabled={{ .Values.webserver.enabled }}
+-Dquine.webserver.address={{ .Values.webserver.address }}
+-Dquine.webserver.port={{ .Values.webserver.port }}
+-Dquine.webserver.use-tls={{ .Values.webserver.useTls }}
+-Dquine.webserver.use-m-tls={{ .Values.webserver.useMTls }}
+{{- end }}
+
+{{/*
 Store Config Section
 */}}
 {{- define "quine.storeConfiguration" -}}
@@ -125,12 +136,18 @@ livenessProbe:
   httpGet:
     path: /api/v1/admin/liveness
     port: 8080
+    {{- if .Values.webserver.useTls }}
+    scheme: HTTPS
+    {{- end }}
   initialDelaySeconds: 5
   timeoutSeconds: 10
 readinessProbe:
   httpGet:
     path: /api/v1/admin/liveness
     port: 8080
+    {{- if .Values.webserver.useTls }}
+    scheme: HTTPS
+    {{- end }}
   initialDelaySeconds: 5
   timeoutSeconds: 10
 {{- end }}

--- a/charts/quine/templates/_helpers.tpl
+++ b/charts/quine/templates/_helpers.tpl
@@ -84,6 +84,20 @@ Webserver Config Section
 {{- end }}
 
 {{/*
+Webserver Advertise Config Section
+*/}}
+{{- define "quine.webserverAdvertiseConfiguration" -}}
+{{- if .Values.webserverAdvertise.enabled }}
+{{- if .Values.webserverAdvertise.address }}
+-Dquine.webserver-advertise.address={{ .Values.webserverAdvertise.address }}
+{{- end }}
+{{- if .Values.webserverAdvertise.port }}
+-Dquine.webserver-advertise.port={{ .Values.webserverAdvertise.port }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 Store Config Section
 */}}
 {{- define "quine.storeConfiguration" -}}

--- a/charts/quine/templates/_helpers.tpl
+++ b/charts/quine/templates/_helpers.tpl
@@ -157,17 +157,19 @@ Liveness and Readiness Probes
 {{- if .Values.webserver.useMTls.enabled }}
 {{- if .Values.webserver.useMTls.healthEndpoints.enabled }}
 livenessProbe:
-  httpGet:
-    path: /api/v1/admin/liveness
-    port: {{ .Values.webserver.useMTls.healthEndpoints.port }}
-    host: 127.0.0.1
+  exec:
+    command:
+      - /bin/sh
+      - -c
+      - curl --silent -f -o /dev/null http://127.0.0.1:{{ .Values.webserver.useMTls.healthEndpoints.port }}/api/v1/admin/liveness
   initialDelaySeconds: 5
   timeoutSeconds: 10
 readinessProbe:
-  httpGet:
-    path: /api/v1/admin/liveness
-    port: {{ .Values.webserver.useMTls.healthEndpoints.port }}
-    host: 127.0.0.1
+  exec:
+    command:
+      - /bin/sh
+      - -c
+      - curl --silent -f -o /dev/null http://127.0.0.1:{{ .Values.webserver.useMTls.healthEndpoints.port }}/api/v1/admin/liveness
   initialDelaySeconds: 5
   timeoutSeconds: 10
 {{- end }}

--- a/charts/quine/templates/_helpers.tpl
+++ b/charts/quine/templates/_helpers.tpl
@@ -85,6 +85,10 @@ Webserver Config Section
 -Dquine.webserver.use-mtls.trust-store.path={{ .Values.webserver.useMTls.trustStore.path }}
 -Dquine.webserver.use-mtls.trust-store.password={{ .Values.webserver.useMTls.trustStore.password }}
 {{- end }}
+{{- if .Values.webserver.useMTls.healthEndpoints }}
+-Dquine.webserver.use-mtls.health-endpoints.enabled={{ .Values.webserver.useMTls.healthEndpoints.enabled }}
+-Dquine.webserver.use-mtls.health-endpoints.port={{ .Values.webserver.useMTls.healthEndpoints.port }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -151,25 +155,22 @@ Liveness and Readiness Probes
 */}}
 {{- define "quine.probes" -}}
 {{- if .Values.webserver.useMTls.enabled }}
-{{- if not .Values.webserver.useMTls.clientCertificateConfigMap }}
-{{- fail "webserver.useMTls.enabled is true but clientCertificateConfigMap is not set" }}
-{{- end }}
+{{- if .Values.webserver.useMTls.healthEndpoints.enabled }}
 livenessProbe:
-  exec:
-    command:
-      - /bin/sh
-      - -c
-      - curl --cacert /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}/ca.pem --cert /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}/client.pem --key /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}/client-key.pem --silent -f -o /dev/null https://localhost:8080/api/v1/admin/liveness
+  httpGet:
+    path: /api/v1/admin/liveness
+    port: {{ .Values.webserver.useMTls.healthEndpoints.port }}
+    host: 127.0.0.1
   initialDelaySeconds: 5
   timeoutSeconds: 10
 readinessProbe:
-  exec:
-    command:
-      - /bin/sh
-      - -c
-      - curl --cacert /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}/ca.pem --cert /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}/client.pem --key /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}/client-key.pem --silent -f -o /dev/null https://localhost:8080/api/v1/admin/liveness
+  httpGet:
+    path: /api/v1/admin/liveness
+    port: {{ .Values.webserver.useMTls.healthEndpoints.port }}
+    host: 127.0.0.1
   initialDelaySeconds: 5
   timeoutSeconds: 10
+{{- end }}
 {{- else }}
 livenessProbe:
   httpGet:

--- a/charts/quine/templates/_helpers.tpl
+++ b/charts/quine/templates/_helpers.tpl
@@ -81,6 +81,10 @@ Webserver Config Section
 -Dquine.webserver.port={{ .Values.webserver.port }}
 -Dquine.webserver.use-tls={{ .Values.webserver.useTls }}
 -Dquine.webserver.use-mtls.enabled={{ .Values.webserver.useMTls.enabled }}
+{{- if and .Values.webserver.useMTls.trustStore .Values.webserver.useMTls.trustStore.path .Values.webserver.useMTls.trustStore.password }}
+-Dquine.webserver.use-mtls.trust-store.path={{ .Values.webserver.useMTls.trustStore.path }}
+-Dquine.webserver.use-mtls.trust-store.password={{ .Values.webserver.useMTls.trustStore.password }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/quine/templates/_helpers.tpl
+++ b/charts/quine/templates/_helpers.tpl
@@ -146,6 +146,24 @@ Cassandra Auth Environment
 Liveness and Readiness Probes
 */}}
 {{- define "quine.probes" -}}
+{{- if .Values.webserver.useMTls }}
+livenessProbe:
+  exec:
+    command:
+      - /bin/sh
+      - -c
+      - curl --cacert /certs/ca.pem --cert /certs/client.pem --key /certs/client-key.pem --silent -f -o /dev/null https://localhost:8080/api/v1/admin/liveness
+  initialDelaySeconds: 5
+  timeoutSeconds: 10
+readinessProbe:
+  exec:
+    command:
+      - /bin/sh
+      - -c
+      - curl --cacert /certs/ca.pem --cert /certs/client.pem --key /certs/client-key.pem --silent -f -o /dev/null https://localhost:8080/api/v1/admin/liveness
+  initialDelaySeconds: 5
+  timeoutSeconds: 10
+{{- else }}
 livenessProbe:
   httpGet:
     path: /api/v1/admin/liveness
@@ -164,6 +182,7 @@ readinessProbe:
     {{- end }}
   initialDelaySeconds: 5
   timeoutSeconds: 10
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/quine/templates/_helpers.tpl
+++ b/charts/quine/templates/_helpers.tpl
@@ -80,7 +80,7 @@ Webserver Config Section
 -Dquine.webserver.address={{ .Values.webserver.address }}
 -Dquine.webserver.port={{ .Values.webserver.port }}
 -Dquine.webserver.use-tls={{ .Values.webserver.useTls }}
--Dquine.webserver.use-m-tls={{ .Values.webserver.useMTls.enabled }}
+-Dquine.webserver.use-mtls.enabled={{ .Values.webserver.useMTls.enabled }}
 {{- end }}
 
 {{/*

--- a/charts/quine/templates/deployment.yaml
+++ b/charts/quine/templates/deployment.yaml
@@ -61,18 +61,9 @@ spec:
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{- if .Values.webserver.useMTls }}
-            - name: ca-certificates
-              mountPath: /certs/ca.pem
-              subPath: ca.pem
-              readOnly: true
-            - name: client-certificates
-              mountPath: /certs/client.pem
-              subPath: client.pem
-              readOnly: true
-            - name: client-certificates
-              mountPath: /certs/client-key.pem
-              subPath: client-key.pem
+            {{- if .Values.webserver.useMTls.enabled }}
+            - name: tls-certificates
+              mountPath: /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}
               readOnly: true
             {{- end }}
           terminationMessagePath: /dev/termination-log
@@ -81,14 +72,10 @@ spec:
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- if .Values.webserver.useMTls }}
-        - name: ca-certificates
+        {{- if .Values.webserver.useMTls.enabled }}
+        - name: tls-certificates
           configMap:
-            name: ca-certificates
-            defaultMode: 0444
-        - name: client-certificates
-          configMap:
-            name: client-certificates
+            name: {{ .Values.webserver.useMTls.clientCertificateConfigMap }}
             defaultMode: 0444
         {{- end }}
       {{- with .Values.nodeSelector }}

--- a/charts/quine/templates/deployment.yaml
+++ b/charts/quine/templates/deployment.yaml
@@ -61,11 +61,35 @@ spec:
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- if .Values.webserver.useMTls }}
+            - name: ca-certificates
+              mountPath: /certs/ca.pem
+              subPath: ca.pem
+              readOnly: true
+            - name: client-certificates
+              mountPath: /certs/client.pem
+              subPath: client.pem
+              readOnly: true
+            - name: client-certificates
+              mountPath: /certs/client-key.pem
+              subPath: client-key.pem
+              readOnly: true
+            {{- end }}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
       volumes:
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.webserver.useMTls }}
+        - name: ca-certificates
+          configMap:
+            name: ca-certificates
+            defaultMode: 0444
+        - name: client-certificates
+          configMap:
+            name: client-certificates
+            defaultMode: 0444
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/quine/templates/deployment.yaml
+++ b/charts/quine/templates/deployment.yaml
@@ -49,6 +49,7 @@ spec:
               {{ include "quine.persistenceConfiguration" . | nindent 14 }}
               {{ include "quine.storeConfiguration" . | nindent 14 }}
               {{ include "quine.metricsConfiguration" . | nindent 14 }}
+              {{ include "quine.webserverConfiguration" . | nindent 14 }}
               {{ include "quine.prometheusJdkOptions" . | nindent 14 }}
               {{ .Values.extraJdkArgs }}
           {{ include "quine.cassandraAuthEnv" . | nindent 10 }}

--- a/charts/quine/templates/deployment.yaml
+++ b/charts/quine/templates/deployment.yaml
@@ -61,22 +61,11 @@ spec:
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{- if .Values.webserver.useMTls.enabled }}
-            - name: tls-certificates
-              mountPath: /certs/{{ .Values.webserver.useMTls.clientCertificateConfigMap }}
-              readOnly: true
-            {{- end }}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
       volumes:
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- if .Values.webserver.useMTls.enabled }}
-        - name: tls-certificates
-          configMap:
-            name: {{ .Values.webserver.useMTls.clientCertificateConfigMap }}
-            defaultMode: 0444
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/quine/templates/deployment.yaml
+++ b/charts/quine/templates/deployment.yaml
@@ -50,6 +50,7 @@ spec:
               {{ include "quine.storeConfiguration" . | nindent 14 }}
               {{ include "quine.metricsConfiguration" . | nindent 14 }}
               {{ include "quine.webserverConfiguration" . | nindent 14 }}
+              {{ include "quine.webserverAdvertiseConfiguration" . | nindent 14 }}
               {{ include "quine.prometheusJdkOptions" . | nindent 14 }}
               {{ .Values.extraJdkArgs }}
           {{ include "quine.cassandraAuthEnv" . | nindent 10 }}

--- a/charts/quine/values.yaml
+++ b/charts/quine/values.yaml
@@ -13,7 +13,9 @@ webserver:
   address: 0.0.0.0
   port: 8080
   useTls: false
-  useMTls: false
+  useMTls:
+    enabled: false
+    clientCertificateConfigMap: ""
 
 webserverAdvertise:
   enabled: false
@@ -21,12 +23,19 @@ webserverAdvertise:
   port:
 
 # mTLS Configuration
-# When webserver.useMTls is enabled, the following ConfigMaps must be created in the cluster:
-# - ca-certificates: Contains the CA certificate in PEM format with key 'ca.pem'
-# - client-certificates: Contains client certificate and key with keys 'client.pem' and 'client-key.pem'
+# When webserver.useMTls.enabled is true, a ConfigMap containing client certificates must be specified.
+# The ConfigMap should contain three files in PEM format:
+# - ca.pem: CA certificate for verifying the server
+# - client.pem: Client certificate for mTLS authentication
+# - client-key.pem: Client private key for mTLS authentication
 #
-# These are automatically mounted when useMTls is true.
-# The install script in the pentesting directory can create these ConfigMaps from JKS keystores.
+# Example ConfigMap creation:
+#   kubectl create configmap my-tls-certs \
+#     --from-file=ca.pem=path/to/ca.pem \
+#     --from-file=client.pem=path/to/client.pem \
+#     --from-file=client-key.pem=path/to/client-key.pem
+#
+# Then set: webserver.useMTls.clientCertificateConfigMap: my-tls-certs
 
 # Cassandra Persistor Settings: Set enabled to true in order to configure the
 # cassandra persistor. 

--- a/charts/quine/values.yaml
+++ b/charts/quine/values.yaml
@@ -20,6 +20,14 @@ webserverAdvertise:
   address:
   port:
 
+# mTLS Configuration
+# When webserver.useMTls is enabled, the following ConfigMaps must be created in the cluster:
+# - ca-certificates: Contains the CA certificate in PEM format with key 'ca.pem'
+# - client-certificates: Contains client certificate and key with keys 'client.pem' and 'client-key.pem'
+#
+# These are automatically mounted when useMTls is true.
+# The install script in the pentesting directory can create these ConfigMaps from JKS keystores.
+
 # Cassandra Persistor Settings: Set enabled to true in order to configure the
 # cassandra persistor. 
 # NOTE: For now the cassandra persistor is the only external persistor

--- a/charts/quine/values.yaml
+++ b/charts/quine/values.yaml
@@ -16,6 +16,9 @@ webserver:
   useMTls:
     enabled: false
     clientCertificateConfigMap: ""
+    # trustStore:
+    #   path: ""
+    #   password: ""
 
 webserverAdvertise:
   enabled: false

--- a/charts/quine/values.yaml
+++ b/charts/quine/values.yaml
@@ -15,6 +15,11 @@ webserver:
   useTls: false
   useMTls: false
 
+webserverAdvertise:
+  enabled: false
+  address:
+  port:
+
 # Cassandra Persistor Settings: Set enabled to true in order to configure the
 # cassandra persistor. 
 # NOTE: For now the cassandra persistor is the only external persistor

--- a/charts/quine/values.yaml
+++ b/charts/quine/values.yaml
@@ -8,6 +8,13 @@ thatdot:
   # Possible values: ERROR, WARN, INFO, DEBUG
   logLevel: WARN
 
+webserver:
+  enabled: true
+  address: 0.0.0.0
+  port: 8080
+  useTls: false
+  useMTls: false
+
 # Cassandra Persistor Settings: Set enabled to true in order to configure the
 # cassandra persistor. 
 # NOTE: For now the cassandra persistor is the only external persistor

--- a/charts/quine/values.yaml
+++ b/charts/quine/values.yaml
@@ -15,7 +15,9 @@ webserver:
   useTls: false
   useMTls:
     enabled: false
-    clientCertificateConfigMap: ""
+    healthEndpoints:
+      enabled: false
+      port: 8081
     # trustStore:
     #   path: ""
     #   password: ""
@@ -26,19 +28,10 @@ webserverAdvertise:
   port:
 
 # mTLS Configuration
-# When webserver.useMTls.enabled is true, a ConfigMap containing client certificates must be specified.
-# The ConfigMap should contain three files in PEM format:
-# - ca.pem: CA certificate for verifying the server
-# - client.pem: Client certificate for mTLS authentication
-# - client-key.pem: Client private key for mTLS authentication
-#
-# Example ConfigMap creation:
-#   kubectl create configmap my-tls-certs \
-#     --from-file=ca.pem=path/to/ca.pem \
-#     --from-file=client.pem=path/to/client.pem \
-#     --from-file=client-key.pem=path/to/client-key.pem
-#
-# Then set: webserver.useMTls.clientCertificateConfigMap: my-tls-certs
+# When webserver.useMTls.enabled is true:
+# - If healthEndpoints.enabled is true, health probes will use HTTP on the loopback
+#   address with the configured healthEndpoints.port
+# - If healthEndpoints.enabled is false, health probes will be disabled
 
 # Cassandra Persistor Settings: Set enabled to true in order to configure the
 # cassandra persistor. 


### PR DESCRIPTION
Adds webserver and webserver advertise helm values. Also includes mTLS configuration.

When TLS is enabled, use the HTTPS scheme. When mTLS is enabled, use provided CA cert, Client Cert, and Client key, to enable health probes to succeed. They also work as proof of mTLS being enabled and working.